### PR TITLE
Consume bin/gen-kube from quarks-utils

### DIFF
--- a/bin/gen-kube
+++ b/bin/gen-kube
@@ -6,24 +6,21 @@ set -o pipefail
 
 GO111MODULE=${GO111MODULE:-on} #Always on, so it works also inside GOPATH
 GIT_ROOT=${GIT_ROOT:-$(git rev-parse --show-toplevel)}
+PROJECT="quarks-operator"
+# The groups and their versions in the format "groupA:v1,v2 groupB:v1 groupC:v2"
+GROUP_VERSIONS="boshdeployment:v1alpha1 quarksstatefulset:v1alpha1 quarkssecret:v1alpha1"
+QUARKS_UTILS=${QUARKS_UTILS:-../quarks-utils}
+
 cd "$GIT_ROOT"
 
-if [ -z ${CODEGEN_PKG+x} ] || [ ! -d "$CODEGEN_PKG" ]; then
-  echo 'Please set CODEGEN_PKG to the location of kubernetes/code-generator'
-  echo 'Make sure version of code-generator matches version of used kubernetes libraries.'
-  echo 'Tag 1.18.2 was last used'.
+if [ -z ${QUARKS_UTILS+x} ] || [ ! -d "$QUARKS_UTILS" ]; then
+  echo 'Please set QUARKS_UTILS to the location of code.cloudfoundry.org/quarks-utils'
+  echo 'git clone https://github.com/cloudfoundry-incubator/quarks-utils.git ../quarks-utils'
   echo
-  echo 'git clone https://github.com/kubernetes/code-generator.git ../code-generator'
-  echo
-  echo 'IMPORTANT! Remember that all generated code is created in your GOPATH.'
   exit 1
 fi
 
-# The groups and their versions in the format "groupA:v1,v2 groupB:v1 groupC:v2"
-GROUP_VERSIONS="boshdeployment:v1alpha1 quarksstatefulset:v1alpha1 quarkssecret:v1alpha1"
-
-env GO111MODULE="$GO111MODULE" "${CODEGEN_PKG}/generate-groups.sh" "deepcopy,client,lister" \
-  code.cloudfoundry.org/quarks-operator/pkg/kube/client \
-  code.cloudfoundry.org/quarks-operator/pkg/kube/apis \
-  "${GROUP_VERSIONS}" \
-  --go-header-file "${GIT_ROOT}/gen/header.go.txt"
+export GIT_ROOT
+export PROJECT
+export GROUP_VERSIONS
+$QUARKS_UTILS/bin/gen-kube

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module code.cloudfoundry.org/quarks-operator
 
 require (
 	code.cloudfoundry.org/quarks-job v1.0.149
-	code.cloudfoundry.org/quarks-utils v0.0.0-20200508141127-47307e498e12
+	code.cloudfoundry.org/quarks-utils v0.0.0-20200512070940-c6dcee3e25a9
 	github.com/SUSE/go-patch v0.3.0
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bmatcuk/doublestar v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,7 @@ code.cloudfoundry.org/quarks-job v1.0.149 h1:omyXhWVO6f1DEOQ2vkaftCbAcWwsYr8Ba5Q
 code.cloudfoundry.org/quarks-job v1.0.149/go.mod h1:rrE1M2QwmA8a9piqOCAHJv40/nmeztK0Hh/Oqae4jKM=
 code.cloudfoundry.org/quarks-utils v0.0.0-20200508141127-47307e498e12 h1:8qLQTH6WV2Jlwb8w2kCjTV/W4/1EaXmtI/Rk420Px24=
 code.cloudfoundry.org/quarks-utils v0.0.0-20200508141127-47307e498e12/go.mod h1:MxdilS/wL1D5NokUPCGR3AX1PqCwCQc+ex8Jk87lbgU=
+code.cloudfoundry.org/quarks-utils v0.0.0-20200512070940-c6dcee3e25a9/go.mod h1:voPdeHf5x70u82CBFDCisvVFhxpXKuUEjd+b8y4Dcwo=
 github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78/go.mod h1:LmzpDX56iTiv29bbRTIsUNlaFfuhWRQBWjQdVyAevI8=
 github.com/Azure/go-autorest/autorest v0.9.0/go.mod h1:xyHB1BMZT0cuDHU7I0+g046+BFDTQ8rEZB0s4Yfa6bI=
 github.com/Azure/go-autorest/autorest/adal v0.5.0/go.mod h1:8Z9fGy2MpX0PvDjB1pEgQTmVqjGhiHBW7RJJEciWzS0=

--- a/pkg/kubecodegen/pin.go
+++ b/pkg/kubecodegen/pin.go
@@ -1,0 +1,10 @@
+// +build tools
+
+// Dummy package to pin kubernetes/code-generator
+// from go.mod used by 'make kube-gen'.
+// Required to allow "go mod vendor" to fetch the same kubecodegen
+// version pinned in quarks-utils
+
+package codegen
+
+import 	_ "code.cloudfoundry.org/quarks-utils/pkg/kubecodegen" 


### PR DESCRIPTION
[172599016](https://www.pivotaltracker.com/story/show/172599016)

Depends on: https://github.com/cloudfoundry-incubator/quarks-utils/pull/45

Consume `gen-kube` from quarks-utils.
Caveat: it needs a checkout of quarks-utils, too. 

I couldn't still manage to make `go mod vendor` to download scripts in quarks-utils.