### PR TITLE
Fix bug with multiple versions when updating

### DIFF
--- a/pkg/kube/controllers/boshdeployment/bpm_reconciler.go
+++ b/pkg/kube/controllers/boshdeployment/bpm_reconciler.go
@@ -197,14 +197,15 @@ func (r *ReconcileBPM) applyBPMResources(bdplName string, instanceGroupName stri
 			return nil, errors.Errorf("Failed to get QuarksStatefulSet instance '%s/%s': %v", bpmSecret.Namespace, quarksStatefulSetName, err)
 		}
 	}
-	_, qStsVersion, err := qstscontroller.GetMaxStatefulSetVersion(r.ctx, r.client, quarksStatefulSet)
-	if err != nil {
-		return nil, err
-	}
-	qStsVersion = qStsVersion + 1
-	qStsVersionString := strconv.Itoa(qStsVersion)
-	if err != nil {
-		return nil, err
+
+	qStsVersionString := "0"
+	if quarksStatefulSet.Namespace != "" {
+		_, qStsVersion, err := qstscontroller.GetMaxStatefulSetVersion(r.ctx, r.client, quarksStatefulSet)
+		if err != nil {
+			return nil, err
+		}
+		qStsVersion = qStsVersion + 1
+		qStsVersionString = strconv.Itoa(qStsVersion)
 	}
 
 	igResolvedSecretVersion, err := r.fetchIGresolvedVersion(bpmSecret.Namespace, instanceGroupName)

--- a/pkg/kube/controllers/boshdeployment/validating_webhook.go
+++ b/pkg/kube/controllers/boshdeployment/validating_webhook.go
@@ -34,7 +34,7 @@ func NewBOSHDeploymentValidator(log *zap.SugaredLogger, config *config.Config) *
 
 	boshDeploymentValidator := NewValidator(log, config)
 
-	globalScopeType := admissionregistration.ScopeType("*")
+	globalScopeType := admissionregistration.NamespacedScope
 	return &wh.OperatorWebhook{
 		FailurePolicy: admissionregistration.Fail,
 		Rules: []admissionregistration.RuleWithOperations{

--- a/pkg/kube/controllers/quarkslink/pod_webhook.go
+++ b/pkg/kube/controllers/quarkslink/pod_webhook.go
@@ -10,16 +10,18 @@ import (
 	"code.cloudfoundry.org/quarks-operator/pkg/kube/util/monitorednamespace"
 	wh "code.cloudfoundry.org/quarks-operator/pkg/kube/util/webhook"
 	"code.cloudfoundry.org/quarks-utils/pkg/config"
+	"code.cloudfoundry.org/quarks-utils/pkg/logger"
 	"code.cloudfoundry.org/quarks-utils/pkg/names"
 )
 
 // NewBOSHLinkPodMutator returns a new webhook to mount BOSH link secrets on entangled pods
 func NewBOSHLinkPodMutator(log *zap.SugaredLogger, config *config.Config) *wh.OperatorWebhook {
+	log = logger.Unskip(log, "boshlink-mutator")
 	log.Info("Setting up mutator for mounting BOSH links in entangled pods")
 
 	mutator := NewPodMutator(log, config)
 
-	globalScopeType := admissionregistration.ScopeType("*")
+	globalScopeType := admissionregistration.NamespacedScope
 	return &wh.OperatorWebhook{
 		FailurePolicy: admissionregistration.Fail,
 		Rules: []admissionregistration.RuleWithOperations{

--- a/pkg/kube/controllers/quarksstatefulset/pod_mutator.go
+++ b/pkg/kube/controllers/quarksstatefulset/pod_mutator.go
@@ -66,7 +66,6 @@ func (m *PodMutator) Handle(ctx context.Context, req admission.Request) admissio
 
 // mutatePodsFn add a pod-ordinal label to the given pod
 func (m *PodMutator) mutatePodsFn(ctx context.Context, pod *corev1.Pod) error {
-
 	m.log.Infof("Mutating Pod '%s/%s'", pod.Namespace, pod.Name)
 
 	// Add pod ordinal label for service selectors

--- a/pkg/kube/controllers/quarksstatefulset/pod_webhook.go
+++ b/pkg/kube/controllers/quarksstatefulset/pod_webhook.go
@@ -10,16 +10,18 @@ import (
 	"code.cloudfoundry.org/quarks-operator/pkg/kube/util/monitorednamespace"
 	wh "code.cloudfoundry.org/quarks-operator/pkg/kube/util/webhook"
 	"code.cloudfoundry.org/quarks-utils/pkg/config"
+	"code.cloudfoundry.org/quarks-utils/pkg/logger"
 	"code.cloudfoundry.org/quarks-utils/pkg/names"
 )
 
 // NewQuarksStatefulSetPodMutator creates a quarksStatefulSet pod mutator for managing volumes
 func NewQuarksStatefulSetPodMutator(log *zap.SugaredLogger, config *config.Config) *wh.OperatorWebhook {
+	log = logger.Unskip(log, "quarks-statefulset-pod-mutator")
 	log.Info("Setting up mutator for quarksStatefulSet pods")
 
 	quarksStatefulSetMutator := NewPodMutator(log, config)
 
-	globalScopeType := admissionregistration.ScopeType("*")
+	globalScopeType := admissionregistration.NamespacedScope
 	return &wh.OperatorWebhook{
 		FailurePolicy: admissionregistration.Fail,
 		Rules: []admissionregistration.RuleWithOperations{

--- a/pkg/kube/controllers/quarksstatefulset/quarksstatefulset_reconciler.go
+++ b/pkg/kube/controllers/quarksstatefulset/quarksstatefulset_reconciler.go
@@ -119,7 +119,9 @@ func (r *ReconcileQuarksStatefulSet) Reconcile(request reconcile.Request) (recon
 
 	for _, desiredStatefulSet := range desiredStatefulSets {
 		// If it doesn't exist, create it
-		ctxlog.Info(ctx, "StatefulSet '", desiredStatefulSet.Name, "' owned by QuarksStatefulSet '", request.NamespacedName, "' not found, will be created.")
+		ctxlog.Infof(ctx, "StatefulSet '%s' owned by QuarksStatefulSet '%s' not found, will be created.",
+			request.NamespacedName,
+			desiredStatefulSet.Name)
 
 		if err = r.versionedSecretStore.SetSecretReferences(ctx, request.Namespace, &qStatefulSet.Spec.Template.Spec.Template.Spec); err != nil {
 			return reconcile.Result{}, ctxlog.WithEvent(qStatefulSet, "UpdateVersionedSecretReferencesError").Error(ctx, "Could not update versioned secret references in pod spec for QuarksStatefulSet '", request.NamespacedName, "': ", err)
@@ -182,7 +184,7 @@ func (r *ReconcileQuarksStatefulSet) calculateDesiredStatefulSets(ctx context.Co
 	}
 
 	desiredVersion := currentVersion + 1
-	ctxlog.Infof(ctx, "Creating new version '%s' for QuarksStatefulSet '%s'", desiredVersion, qStatefulSet.GetNamespacedName())
+	ctxlog.Infof(ctx, "Creating new version '%d' for QuarksStatefulSet '%s'", desiredVersion, qStatefulSet.GetNamespacedName())
 
 	if qStatefulSet.Spec.ZoneNodeLabel == "" {
 		qStatefulSet.Spec.ZoneNodeLabel = qstsv1a1.DefaultZoneNodeLabel

--- a/pkg/kube/controllers/quarksstatefulset/util.go
+++ b/pkg/kube/controllers/quarksstatefulset/util.go
@@ -27,6 +27,10 @@ func GetMaxStatefulSetVersion(ctx context.Context, client crc.Client, qStatefulS
 	}
 	maxVersion := 0
 
+	if qStatefulSet.Namespace == "" {
+		return result, maxVersion, nil
+	}
+
 	statefulSets, err := listStatefulSetsFromInformer(ctx, client, qStatefulSet)
 	if err != nil {
 		return nil, 0, err

--- a/pkg/kube/controllers/statefulset/statefulset_webhook.go
+++ b/pkg/kube/controllers/statefulset/statefulset_webhook.go
@@ -17,6 +17,7 @@ import (
 	"code.cloudfoundry.org/quarks-operator/pkg/kube/util/monitorednamespace"
 	wh "code.cloudfoundry.org/quarks-operator/pkg/kube/util/webhook"
 	"code.cloudfoundry.org/quarks-utils/pkg/config"
+	"code.cloudfoundry.org/quarks-utils/pkg/logger"
 	"code.cloudfoundry.org/quarks-utils/pkg/names"
 )
 
@@ -84,11 +85,12 @@ func (m *Mutator) Handle(ctx context.Context, req admission.Request) admission.R
 
 // NewStatefulSetRolloutMutator creates a statefulset mutator for setting the partion
 func NewStatefulSetRolloutMutator(log *zap.SugaredLogger, config *config.Config) *wh.OperatorWebhook {
+	log = logger.Unskip(log, "sts-rollout-mutator")
 	log.Info("Setting up mutator for statefulsets")
 
 	mutator := NewMutator(log, config)
 
-	globalScopeType := admissionregistration.ScopeType("*")
+	globalScopeType := admissionregistration.NamespacedScope
 	return &wh.OperatorWebhook{
 		FailurePolicy: admissionregistration.Fail,
 		Rules: []admissionregistration.RuleWithOperations{

--- a/pkg/kube/controllers/versionedsecret/validating_webhook.go
+++ b/pkg/kube/controllers/versionedsecret/validating_webhook.go
@@ -19,17 +19,19 @@ import (
 	"code.cloudfoundry.org/quarks-operator/pkg/kube/util/monitorednamespace"
 	wh "code.cloudfoundry.org/quarks-operator/pkg/kube/util/webhook"
 	"code.cloudfoundry.org/quarks-utils/pkg/config"
+	"code.cloudfoundry.org/quarks-utils/pkg/logger"
 	"code.cloudfoundry.org/quarks-utils/pkg/names"
 	vss "code.cloudfoundry.org/quarks-utils/pkg/versionedsecretstore"
 )
 
 // NewSecretValidator creates a validating hook to deny updates to versioned secrets and adds it to the manager.
 func NewSecretValidator(log *zap.SugaredLogger, config *config.Config) *wh.OperatorWebhook {
+	log = logger.Unskip(log, "secret-validator")
 	log.Info("Setting up validator for versioned secrets")
 
 	secretValidator := NewValidationHandler(log)
 
-	globalScopeType := admissionregistration.ScopeType("*")
+	globalScopeType := admissionregistration.NamespacedScope
 	return &wh.OperatorWebhook{
 		FailurePolicy: admissionregistration.Fail,
 		Rules: []admissionregistration.RuleWithOperations{


### PR DESCRIPTION
This should fix the tests.

* GetMaxStatefulSetVersion was called with an empty namespace.
* The webhooks scoping was not taking effect, because the scope was still
set to '*'
* Also fixes logged code location in webhooks

[#165900520](https://www.pivotaltracker.com/story/show/165900520)