### PR TITLE
Update s390x Dockerfile

### DIFF
--- a/Dockerfile-s390x
+++ b/Dockerfile-s390x
@@ -1,4 +1,4 @@
-ARG quarkz_base_version="0.0.0"
+ARG quarkz_base_version="0.0.6"
 
 FROM s390x/alpine AS dumb-init
 ADD https://github.com/Yelp/dumb-init/releases/download/v1.2.2/dumb-init_1.2.2_s390x /usr/bin/dumb-init
@@ -19,7 +19,7 @@ COPY . .
 RUN make build && \
     cp -p binaries/cf-operator /usr/local/bin/cf-operator
 
-FROM cfcontainerization/quarkz:$quarkz_base_version
+FROM quarkz/cf-operator-base:$quarkz_base_version
 RUN groupadd -g 1000 vcap && \
     useradd -r -u 1000 -g vcap vcap
 USER vcap


### PR DESCRIPTION
Update needed for the s390x Dockerfile to work 

## Description
Since the cfcontainerization/quarkz docker image was deleted, we uploaded it to the quarkz Docker Hub repository and updated the s390x Dockerfile accordingly.

## Motivation and Context
This allows the build of quarks-operator on s390x architecture. 

## How Has This Been Tested?
Using an s390x architecture VM and running the build. 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.