### PR TITLE
Support nested, type preserving native-to-bosh link properties

### DIFF
--- a/docs/examples/quarks-link/native-to-bosh/link-secret.yaml
+++ b/docs/examples/quarks-link/native-to-bosh/link-secret.yaml
@@ -5,5 +5,6 @@ metadata:
   annotations:
     quarks.cloudfoundry.org/deployment-name: "cf-operator-testing-deployment"
     quarks.cloudfoundry.org/provides: '{"name":"testlink","type":"link"}'
-data:
-  user: YWRtaW4=
+stringData:
+  link: |
+    testlink.user: YWRtaW4=

--- a/integration/storage/suite_test.go
+++ b/integration/storage/suite_test.go
@@ -76,7 +76,7 @@ var _ = BeforeEach(func() {
 		fmt.Printf("WARNING: failed to setup quarks-job operator service account: %s\n", err)
 	}
 
-	err = qjobCmd.Start(env.Namespace)
+	err = qjobCmd.Start(env.Config.MonitoredID)
 	if err != nil {
 		fmt.Printf("WARNING: failed to start operator dependencies: %v\n", err)
 	}
@@ -89,7 +89,7 @@ var _ = BeforeEach(func() {
 
 var _ = AfterEach(func() {
 	env.Teardown(CurrentGinkgoTestDescription().Failed)
-	gexec.KillAndWait()
+	gexec.Kill()
 })
 
 var _ = AfterSuite(func() {

--- a/integration/suite_test.go
+++ b/integration/suite_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"testing"
 
-	cmdHelper "code.cloudfoundry.org/quarks-utils/testing"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gexec"
@@ -12,6 +11,7 @@ import (
 	"k8s.io/client-go/rest"
 
 	"code.cloudfoundry.org/quarks-operator/integration/environment"
+	cmdHelper "code.cloudfoundry.org/quarks-utils/testing"
 	utils "code.cloudfoundry.org/quarks-utils/testing/integration"
 )
 

--- a/integration/util/suite_test.go
+++ b/integration/util/suite_test.go
@@ -6,6 +6,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gexec"
 	"github.com/pkg/errors"
 	"k8s.io/client-go/rest"
 
@@ -16,7 +17,7 @@ import (
 
 func TestUtil(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Util Suite")
+	RunSpecs(t, "Integration Util Suite")
 }
 
 var (
@@ -67,6 +68,7 @@ var _ = BeforeEach(func() {
 
 var _ = AfterEach(func() {
 	env.Teardown(CurrentGinkgoTestDescription().Failed)
+	gexec.Kill()
 })
 
 var _ = AfterSuite(func() {

--- a/pkg/bosh/converter/quarks_links.go
+++ b/pkg/bosh/converter/quarks_links.go
@@ -1,8 +1,11 @@
 package converter
 
 import (
-	"code.cloudfoundry.org/quarks-utils/pkg/names"
+	"path/filepath"
+
 	corev1 "k8s.io/api/core/v1"
+
+	"code.cloudfoundry.org/quarks-utils/pkg/names"
 )
 
 const (
@@ -54,7 +57,7 @@ func (q *LinkInfo) linkVolume() corev1.Volume {
 func (q *LinkInfo) linkVolumeMount() corev1.VolumeMount {
 	return corev1.VolumeMount{
 		Name:      names.VolumeName(q.SecretName),
-		MountPath: VolumeLinksPath + q.ProviderName,
+		MountPath: filepath.Join(VolumeLinksPath, q.ProviderName),
 		ReadOnly:  true,
 	}
 }

--- a/pkg/bosh/manifest/cmd_instance_group_resolver_test.go
+++ b/pkg/bosh/manifest/cmd_instance_group_resolver_test.go
@@ -383,25 +383,19 @@ var _ = Describe("InstanceGroupResolver", func() {
 					Expect(err).NotTo(HaveOccurred())
 					ig = "log-api"
 
-					fileP1, err := fs.Create(converter.VolumeLinksPath + "doppler/fooprop")
+					fileP1, err := fs.Create(converter.VolumeLinksPath + "doppler/link")
 					Expect(err).NotTo(HaveOccurred())
 					defer fileP1.Close()
-					_, err = fileP1.WriteString("fake_prop")
+					_, err = fileP1.WriteString(`{"doppler.fooprop":"fake_prop","doppler.grpc_port":"7765","doppler.int":123, "doppler.nested.truth":false,"doppler.map":{"key":"value"}}}`)
 					Expect(err).NotTo(HaveOccurred())
-
-					fileP2, err := fs.Create(converter.VolumeLinksPath + "doppler/grpc_port")
-					Expect(err).NotTo(HaveOccurred())
-					defer fileP2.Close()
-					_, err = fileP2.WriteString(`7765`)
-					Expect(err).NotTo(HaveOccurred())
-
 				})
 
 				It("loads the external link properties and adds them", func() {
 					err = igr.CollectQuarksLinks(converter.VolumeLinksPath)
 					Expect(err).ToNot(HaveOccurred())
 
-					resolve()
+					err := igr.Resolve(true)
+					Expect(err).ToNot(HaveOccurred())
 					m, err := igr.Manifest()
 					Expect(err).ToNot(HaveOccurred())
 					// log-api instance_group, with loggregator_trafficcontroller job, consumes links from external doppler
@@ -421,6 +415,9 @@ var _ = Describe("InstanceGroupResolver", func() {
 							"doppler": map[string]interface{}{
 								"grpc_port": "7765",
 								"fooprop":   "fake_prop",
+								"int":       123,
+								"nested":    map[string]interface{}{"truth": false},
+								"map":       map[interface{}]interface{}{"key": "value"},
 							},
 						},
 					}))

--- a/pkg/kube/controllers/boshdeployment/deployment_reconciler.go
+++ b/pkg/kube/controllers/boshdeployment/deployment_reconciler.go
@@ -304,7 +304,7 @@ func (r *ReconcileBOSHDeployment) listLinkInfos(bdpl *bdv1.BOSHDeployment, manif
 					})
 
 					if linkProvider.ProviderType != "" {
-						quarksLinks[s.Name] = bdm.QuarksLink{
+						quarksLinks[linkProvider.Name] = bdm.QuarksLink{
 							Type: linkProvider.ProviderType,
 						}
 					}
@@ -318,6 +318,7 @@ func (r *ReconcileBOSHDeployment) listLinkInfos(bdpl *bdv1.BOSHDeployment, manif
 			return linkInfos, errors.Wrapf(err, "failed to get link services for '%s'", bdpl.GetNamespacedName())
 		}
 
+		// Update quarksLinks section `manifest.Properties["quarks_links"]` with info from existing serviceRecords
 		for qName := range quarksLinks {
 			if svcRecord, ok := serviceRecords[qName]; ok {
 				pods, err := r.listPodsFromSelector(bdpl.Namespace, svcRecord.selector)
@@ -364,7 +365,7 @@ func (r *ReconcileBOSHDeployment) listLinkInfos(bdpl *bdv1.BOSHDeployment, manif
 		if manifest.Properties == nil {
 			manifest.Properties = map[string]interface{}{}
 		}
-		manifest.Properties["quarks_links"] = quarksLinks
+		manifest.Properties[bdm.QuarksLinksProperty] = quarksLinks
 	}
 
 	return linkInfos, nil

--- a/testing/catalog_native.go
+++ b/testing/catalog_native.go
@@ -157,12 +157,12 @@ func (c *Catalog) NatsService(deployName string) corev1.Service {
 				"app": "nats",
 			},
 			Ports: []corev1.ServicePort{
-				corev1.ServicePort{
+				{
 					Name:       "client",
 					Port:       4222,
 					TargetPort: intstr.FromString("client"),
 				},
-				corev1.ServicePort{
+				{
 					Name:       "cluster",
 					Port:       6222,
 					TargetPort: intstr.FromString("cluster"),
@@ -183,9 +183,10 @@ func (c *Catalog) NatsSecret(deployName string) corev1.Secret {
 			},
 		},
 		StringData: map[string]string{
-			"user":     "nats_client",
-			"password": "r9fXAlY3gZ",
-			"port":     "4222",
+			"link": `---
+nats.user: nats_client
+nats.password: r9fXAlY3gZ
+nats.port: "4222"`,
 		},
 	}
 }


### PR DESCRIPTION
* from native to bosh, we need to make sure that we preserve type information in links
* when rendering from native links, the flat properties should be converted to a nested map

[#172993878](https://www.pivotaltracker.com/story/show/172993878)


