### PR TITLE
clean up linters and ci

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,12 @@
 name: quarks-operator-ci
 
-on: [push]
+on:
+  push:
+    tags:
+      - v*
+    branches:
+      - master
+  pull_request:
 
 jobs:
   unit-tests:
@@ -77,7 +83,6 @@ jobs:
         bin/build-helm
         bin/build-image
         kind load docker-image "cfcontainerization/cf-operator:dev"
-        export DEBUG=yes
         tools/quarks-utils/bin/test-integration
         INTEGRATION_SUITE=storage tools/quarks-utils/bin/test-integration
         INTEGRATION_SUITE=util tools/quarks-utils/bin/test-integration
@@ -85,6 +90,7 @@ jobs:
         tools/quarks-utils/bin/test-helm-e2e
         bin/test-helm-e2e-storage
       env:
+        DEBUG: "yes"
         GOPROXY: "https://proxy.golang.org"
         OPERATOR_TEST_STORAGE_CLASS: "standard"
         PROJECT: "quarks-operator"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -96,3 +96,8 @@ jobs:
         PROJECT: "quarks-operator"
         DOCKER_IMAGE_TAG: "dev"
         CF_OPERATOR_WEBHOOK_SERVICE_HOST: 172.17.0.1
+    - uses: actions/upload-artifact@v2
+      if: failure()
+      with:
+        name: ginkgo debug logs
+        path: "**/ginkgo-node-*.log"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,11 +25,15 @@ jobs:
         go get -u golang.org/x/lint/golint
         curl -LO https://github.com/dominikh/go-tools/releases/download/2020.1.3/staticcheck_linux_amd64.tar.gz
         sudo tar xfz staticcheck_linux_amd64.tar.gz --strip-component 1 -C $GOPATH/bin staticcheck/staticcheck
+    - name: Install shared tools
+      run: |
+        bin/tools-shared
     - name: Run lint
-      run: make lint vet
+      run: |
+        tools/quarks-utils/bin/lint
     - name: Run unit tests
       run: |
-        make test-unit
+        tools/quarks-utils/bin/test-unit
       env:
         GOPROXY: "https://proxy.golang.org"
 
@@ -58,6 +62,9 @@ jobs:
       run: |
         sudo gem install bosh-template
         go install github.com/onsi/ginkgo/ginkgo
+    - name: Install shared tools
+      run: |
+        bin/tools-shared
     - name: Create k8s Kind Cluster
       uses: engineerd/setup-kind@v0.3.0
       with:
@@ -70,7 +77,6 @@ jobs:
         bin/build-helm
         bin/build-image
         kind load docker-image "cfcontainerization/cf-operator:dev"
-        bin/tools-shared
         export DEBUG=yes
         tools/quarks-utils/bin/test-integration
         INTEGRATION_SUITE=storage tools/quarks-utils/bin/test-integration

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,26 @@
+name: golangci-lint
+
+on:
+  push:
+    tags:
+      - v*
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v1
+        with:
+          # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
+          version: v1.26
+
+          args: --timeout=10m
+
+          # Optional: show only new issues if it's a pull request. The default value is `false`.
+          # only-new-issues: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,36 @@
+run:
+  deadline: 20s
+linters-settings:
+  dupl:
+    threshold: 400
+issues:
+  # don't skip warning about doc comments
+  exclude-use-default: false
+
+  # restore some of the defaults
+  # (fill in the rest as needed)
+  exclude-rules:
+  - linters: [errcheck]
+    text: "Error return value of .((os\\.)?std(out|err)\\..*|.*Close|.*Flush|os\\.Remove(All)?|.*printf?|os\\.(Un)?Setenv). is not checked"
+linters:
+  disable-all: true
+  enable:
+  - misspell
+  - structcheck
+  - golint
+  - govet
+  - staticcheck
+  - deadcode
+  - errcheck
+  - varcheck
+  - goconst
+  - unparam
+  - ineffassign
+  - nakedret
+  - interfacer
+  - gocyclo
+  - dupl
+  - goimports
+  - golint
+  - gosimple
+  - typecheck

--- a/Makefile
+++ b/Makefile
@@ -11,9 +11,6 @@ all: tools build test
 up:
 	bin/up
 
-vet:
-	bin/vet
-
 lint: tools
 	$(QUARKS_UTILS)/bin/lint
 
@@ -29,6 +26,9 @@ vendor:
 
 staticcheck:
 	staticcheck ./...
+
+vet:
+	go list ./... | xargs go vet
 
 ############ BUILD TARGETS ############
 

--- a/bin/vet
+++ b/bin/vet
@@ -1,4 +1,0 @@
-#!/bin/bash
-set -e
-
-go list ./... | xargs go vet

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module code.cloudfoundry.org/quarks-operator
 
 require (
 	code.cloudfoundry.org/quarks-job v1.0.159
-	code.cloudfoundry.org/quarks-secret v0.0.0-20200526102356-c758effddcc4
+	code.cloudfoundry.org/quarks-secret v0.0.0-20200527034647-269daeb7e9ca
 	code.cloudfoundry.org/quarks-utils v0.0.0-20200616125609-bd688d9e9d1d
 	github.com/SUSE/go-patch v0.3.0
 	github.com/beorn7/perks v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -13,8 +13,8 @@ cloud.google.com/go/pubsub v1.0.1/go.mod h1:R0Gpsv3s54REJCy4fxDixWD93lHJMoZTyQ2k
 cloud.google.com/go/storage v1.0.0/go.mod h1:IhtSnM/ZTZV8YYJWCY8RULGVqBDmpoyjwiyrjsg+URw=
 code.cloudfoundry.org/quarks-job v1.0.159 h1:X1KRS8ZiTz/PcntS7nV2GJgX5fNeZByrEmU1WXS2U/g=
 code.cloudfoundry.org/quarks-job v1.0.159/go.mod h1:oJojakrgj7y1GlSs7UaDGvjI4b1wMSU0nm4OC2vZiM4=
-code.cloudfoundry.org/quarks-secret v0.0.0-20200526102356-c758effddcc4 h1:rKwPYRLS8qgJGIzfus7y776deW+QA/+48Gtler6BI+8=
-code.cloudfoundry.org/quarks-secret v0.0.0-20200526102356-c758effddcc4/go.mod h1:0NEUHrB9j1T7WQzndlvTthCDQuwglfkte/lavTLC2nI=
+code.cloudfoundry.org/quarks-secret v0.0.0-20200527034647-269daeb7e9ca h1:q8W1AbMFvSIEts/qH1bNnnOhZcQ9hRdfkXHfWWMZClU=
+code.cloudfoundry.org/quarks-secret v0.0.0-20200527034647-269daeb7e9ca/go.mod h1:0NEUHrB9j1T7WQzndlvTthCDQuwglfkte/lavTLC2nI=
 code.cloudfoundry.org/quarks-utils v0.0.0-20200514122617-32f742d5f10e/go.mod h1:voPdeHf5x70u82CBFDCisvVFhxpXKuUEjd+b8y4Dcwo=
 code.cloudfoundry.org/quarks-utils v0.0.0-20200616125609-bd688d9e9d1d h1:s7WS3kQAZJA+C+X+cDye7zEQO1qjEEVgVlaEZG6UGR4=
 code.cloudfoundry.org/quarks-utils v0.0.0-20200616125609-bd688d9e9d1d/go.mod h1:voPdeHf5x70u82CBFDCisvVFhxpXKuUEjd+b8y4Dcwo=


### PR DESCRIPTION
This has several commits from chores, since it's hard to pass CI at the moment...


* split bin/tools
* clean up linters
* bump quarks-secret

[#173009013](https://www.pivotaltracker.com/story/show/173009013)

