### PR TITLE
Allow to override base image in our docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
+ARG BASE_IMAGE=registry.opensuse.org/cloud/platform/quarks/sle_15_sp1/quarks-operator-base:latest
+
 FROM golang:1.13.3 AS build
 ARG GOPROXY
 ENV GOPROXY $GOPROXY
@@ -16,7 +18,7 @@ RUN make build && \
     cp -p binaries/cf-operator /usr/local/bin/cf-operator
 RUN ./bin/build-container-run /usr/local/bin
 
-FROM registry.opensuse.org/cloud/platform/quarks/sle_15_sp1/quarks-operator-base:latest
+FROM $BASE_IMAGE
 RUN groupadd -g 1000 vcap && \
     useradd -r -u 1000 -g vcap vcap
 RUN cp /usr/sbin/dumb-init /usr/bin/dumb-init

--- a/Dockerfile-s390x
+++ b/Dockerfile-s390x
@@ -1,4 +1,5 @@
 ARG quarkz_base_version="0.0.6"
+ARG BASE_IMAGE=quarkz/cf-operator-base:$quarkz_base_version
 
 FROM s390x/alpine AS dumb-init
 ADD https://github.com/Yelp/dumb-init/releases/download/v1.2.2/dumb-init_1.2.2_s390x /usr/bin/dumb-init
@@ -19,7 +20,7 @@ COPY . .
 RUN make build && \
     cp -p binaries/cf-operator /usr/local/bin/cf-operator
 
-FROM quarkz/cf-operator-base:$quarkz_base_version
+FROM $BASE_IMAGE
 RUN groupadd -g 1000 vcap && \
     useradd -r -u 1000 -g vcap vcap
 USER vcap


### PR DESCRIPTION
Allow to swap base image. The base image needs to ship the required dependencies (e.g. dumb-init)

## Motivation and Context

[#173530438](https://www.pivotaltracker.com/story/show/173530438)

## Checklist:

Check item if necessary.

- [ ] Review PRs of changed Quarks dependencies
- [ ] Update this PR after the release of Quarks dependencies
