### PR TITLE
Extend the current AddOns to support BOSH links

### DIFF
--- a/pkg/bosh/manifest/manifest.go
+++ b/pkg/bosh/manifest/manifest.go
@@ -107,9 +107,11 @@ type Release struct {
 
 // AddOnJob from BOSH deployment manifest
 type AddOnJob struct {
-	Name       string        `json:"name"`
-	Release    string        `json:"release"`
-	Properties JobProperties `json:"properties,omitempty"`
+	Name       string                 `json:"name"`
+	Release    string                 `json:"release"`
+	Properties JobProperties          `json:"properties,omitempty"`
+	Consumes   map[string]interface{} `json:"consumes,omitempty"`
+	Provides   map[string]interface{} `json:"provides,omitempty"`
 }
 
 // AddOnStemcell from BOSH deployment manifest
@@ -490,6 +492,8 @@ func (m *Manifest) ApplyAddons(log *zap.SugaredLogger) error {
 					Name:       addonJob.Name,
 					Release:    addonJob.Release,
 					Properties: addonJob.Properties,
+					Consumes:   addonJob.Consumes,
+					Provides:   addonJob.Provides,
 				}
 
 				addedJob.Properties.Quarks.IsAddon = true


### PR DESCRIPTION
This can be easily done by adding the consumes and
provides fields. And allow this to be added to the ig
jobs lExtend the current AddOns to support BOSH links

This can be easily done by adding the consumes and
provides fields. And allow this to be added to the ig
jobs list.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
To support defining consumers under addons jobs, for example:

```yaml
  - type: replace
    path: /addons/name=loggregator_agent/jobs/name=loggregator_agent/consumes?
    value:
      doppler: {from: doppler}
```

<!--- If it fixes an open issue or belongs to a story, please add a link here. -->

This belongs to the multicluster work tracked in KubeCF https://github.com/cloudfoundry-incubator/kubecf/projects/3

## Checklist:

Check item if necessary.

- [ ] Review PRs of changed Quarks dependencies
- [ ] Update this PR after the release of Quarks dependencies
