### PR TITLE
Drop paths-ignore

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,9 +6,6 @@ on:
       - v*
     branches:
       - master
-    paths-ignore:
-    - "docs/**"
-    - "website/**"
   pull_request:
   schedule:
     - cron:  '0 0 * * *'


### PR DESCRIPTION
Leftovers, now docs and website are in a separate repo, and the examples changes account towards a ci run


