### PR TITLE
add fix to multi-az cell DNS issue

### DIFF
--- a/pkg/bosh/manifest/cmd_instance_group_resolver_test.go
+++ b/pkg/bosh/manifest/cmd_instance_group_resolver_test.go
@@ -147,7 +147,7 @@ var _ = Describe("InstanceGroupResolver", func() {
 				// We do not support different indexes in BPM data.
 				Expect(bpm.Processes[0].Env["FOOBARWITHSPECAZ"]).To(Equal("z1"))
 				Expect(bpm.Processes[0].Env["FOOBARWITHSPECBOOTSTRAP"]).To(Equal("true"))
-				Expect(bpm.Processes[0].Env["FOOBARWITHSPECID"]).To(Equal("log-api-0"))
+				Expect(bpm.Processes[0].Env["FOOBARWITHSPECID"]).To(Equal("log-api-z0-0"))
 				Expect(bpm.Processes[0].Env["FOOBARWITHSPECINDEX"]).To(Equal("0"))
 				Expect(bpm.Processes[0].Env["FOOBARWITHSPECNAME"]).To(Equal("log-api-loggregator_trafficcontroller"))
 				Expect(bpm.Processes[0].Env["FOOBARWITHSPECNETWORKS"]).To(Equal(""))

--- a/pkg/bosh/manifest/cmd_render_job_tmpls_test.go
+++ b/pkg/bosh/manifest/cmd_render_job_tmpls_test.go
@@ -104,7 +104,7 @@ var _ = Describe("Trender", func() {
 				// will use the instance at the index provided to the RenderJobTemplates func().
 				Expect(values.Env["FOOBARWITHSPECAZ"]).To(Equal("z1"))
 				Expect(values.Env["FOOBARWITHSPECBOOTSTRAP"]).To(Equal("true"))
-				Expect(values.Env["FOOBARWITHSPECID"]).To(Equal("log-api-0"))
+				Expect(values.Env["FOOBARWITHSPECID"]).To(Equal("log-api-z0-0"))
 				Expect(values.Env["FOOBARWITHSPECINDEX"]).To(Equal("0"))
 				Expect(values.Env["FOOBARWITHSPECNAME"]).To(Equal("log-api-loggregator_trafficcontroller"))
 				Expect(values.Env["FOOBARWITHSPECNETWORKS"]).To(Equal(""))

--- a/pkg/bosh/manifest/instance_group.go
+++ b/pkg/bosh/manifest/instance_group.go
@@ -144,6 +144,12 @@ func (ig *InstanceGroup) generateJobInstances(jobsInstances []JobInstance,
 		index := len(jobsInstances)
 		address := ig.IndexedServiceName(i, azIndex)
 		name := fmt.Sprintf("%s-%s", ig.NameSanitized(), jobName)
+		id := ""
+		if azIndex > -1 {
+			id = fmt.Sprintf("%s-z%d-%d", ig.NameSanitized(), azIndex, index%ig.Instances)
+		} else {
+			id = fmt.Sprintf("%s-%d", ig.NameSanitized(), index)
+		}
 
 		jobsInstances = append(jobsInstances, JobInstance{
 			Address:   address,
@@ -152,10 +158,9 @@ func (ig *InstanceGroup) generateJobInstances(jobsInstances []JobInstance,
 			Index:     index,
 			Instance:  i,
 			Name:      name,
-			ID:        fmt.Sprintf("%s-%d", ig.NameSanitized(), index),
+			ID:        id,
 		})
 	}
-
 	return jobsInstances
 }
 

--- a/pkg/kube/util/boshdns/bosh_test.go
+++ b/pkg/kube/util/boshdns/bosh_test.go
@@ -197,6 +197,7 @@ var _ = Describe("BOSHDomainNameService", func() {
 					&manifest.InstanceGroup{Name: "scheduler", AZs: []string{"az1", "az2"}},
 					&manifest.InstanceGroup{Name: "diego-api", AZs: []string{"az1", "az2"}},
 					&manifest.InstanceGroup{Name: "bits", AZs: []string{"az1", "az2"}},
+					&manifest.InstanceGroup{Name: "diego-cell", AZs: []string{"az1", "az2"}, Instances: 1},
 				}
 				dns = boshdns.NewBoshDomainNameService(igs)
 				err := dns.Add(loadAddOn(aliasAddon))
@@ -246,6 +247,13 @@ var _ = Describe("BOSHDomainNameService", func() {
 	template IN A uaa.service.cf.internal {
 		match ^(([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])\.)*uaa\.service\.cf\.internal\.$
 		answer "{{ .Name }} 60 IN CNAME uaa.default.svc."
+		upstream`))
+
+				By("checking for entries for diego-cells in mutli-zone")
+				Expect(corefile).To(ContainSubstring(`
+	template IN A diego-cell-z0-0.cell.service.cf.internal {
+		match ^diego-cell-z0-0\.cell\.service\.cf\.internal\.$
+		answer "{{ .Name }} 60 IN CNAME diego-cell-z0-0.default.svc."
 		upstream`))
 			})
 		})

--- a/pkg/kube/util/boshdns/corefile.go
+++ b/pkg/kube/util/boshdns/corefile.go
@@ -159,8 +159,13 @@ func gatherRewritesForInstances(rewrites []string,
 	namespace string,
 	azIndex int,
 	alias Alias) []string {
+	id := ""
 	for i := 0; i < instanceGroup.Instances; i++ {
-		id := fmt.Sprintf("%s-%d", target.InstanceGroup, i)
+		if azIndex > -1 {
+			id = fmt.Sprintf("%s-z%d-%d", target.InstanceGroup, azIndex, i)
+		} else {
+			id = fmt.Sprintf("%s-%d", target.InstanceGroup, i)
+		}
 		from := strings.Replace(alias.Domain, "_", id, 1)
 		serviceName := instanceGroup.IndexedServiceName(i, azIndex)
 		to := fmt.Sprintf("%s.%s.svc.%s", serviceName, namespace, clusterDomain)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Add fix for multi-az diego-cell DNS issue

<!--- Describe your changes in detail -->
This will fix the diego-cell incorrect DNS record when multi-az enabled  with below code change:
- add az index into the DNS record for diego-cell
- update instance id with az index to ensure cf jobs can find each other.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This fix the issue that cf jobs fail to find and connect to the correct cell when multi-az enabled.

<!--- If it fixes an open issue or belongs to a story, please add a link here. -->
https://github.com/cloudfoundry-incubator/quarks-operator/issues/1084


