### PR TITLE
Use pre-release version for helm charts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,21 +8,25 @@ export GROUP_VERSIONS ?= boshdeployment:v1alpha1
 
 all: tools build test
 
+setup:
+	# installs ginkgo, counterfeiter, linters, ...
+	# includes bin/tools
+	bin/dev-tools
+
+.PHONY: tools
+tools:
+	bin/tools
+
 up:
 	bin/up
+
+############ LINTER TARGETS ############
 
 lint: tools
 	$(QUARKS_UTILS)/bin/lint
 
-.PHONY: tools
-tools:
-	bin/dev-tools
-
 check-scripts:
 	bin/check-scripts
-
-vendor:
-	go mod vendor
 
 staticcheck:
 	staticcheck ./...
@@ -55,20 +59,21 @@ test-integration: tools
 test-cli-e2e: tools
 	$(QUARKS_UTILS)/bin/test-cli-e2e
 
-test-helm-e2e: tools
+test-helm-e2e: tools build-helm
 	$(QUARKS_UTILS)/bin/test-helm-e2e
 
-test-helm-e2e-storage:
+test-helm-e2e-storage: tools build-helm
 	bin/test-helm-e2e-storage
 
-test-helm-e2e-upgrade:
+test-helm-e2e-upgrade: tools build-helm
 	bin/test-helm-e2e-upgrade
 
-test-integration-storage:
+test-integration-storage: tools
 	INTEGRATION_SUITE=storage $(QUARKS_UTILS)/bin/test-integration
 
-test-integration-subcmds:
+test-integration-subcmds: tools
 	INTEGRATION_SUITE=util $(QUARKS_UTILS)/bin/test-integration
+
 ############ GENERATE TARGETS ############
 
 generate: gen-kube gen-fakes
@@ -76,7 +81,7 @@ generate: gen-kube gen-fakes
 gen-kube: tools
 	$(QUARKS_UTILS)/bin/gen-kube
 
-gen-fakes:
+gen-fakes: setup
 	bin/gen-fakes
 
 gen-command-docs:

--- a/bin/build-helm
+++ b/bin/build-helm
@@ -10,9 +10,17 @@ GIT_ROOT=${GIT_ROOT:-$(git rev-parse --show-toplevel)}
 output_dir="$GIT_ROOT/helm"
 
 # https://semver.org/#semantic-versioning-200
-# helm does not accept ^v and considers any version with a dash to be a
-# pre-release
-version=$(echo "$ARTIFACT_VERSION" | sed 's/^v//; s/-/+/')
+# helm does not accept a leading 'v'
+version=$(echo "$ARTIFACT_VERSION" | sed 's/^v//')
+# helm considers any version with a dash to be a pre-release
+if [ ${RELEASE+x} ]; then
+  # if version contains '-dirty', it's a bug in CI
+  if echo "$version" | grep -q 'dirty'; then
+    echo "release versions may not contain '-dirty': $version"
+    exit 1
+  fi
+  version=$(echo "$version" | sed 's/-/+/')
+fi
 
 [ -d "$output_dir" ] && rm -r "$output_dir"
 cp -r "$GIT_ROOT/deploy/helm" "$output_dir"

--- a/bin/dev-prepare
+++ b/bin/dev-prepare
@@ -6,7 +6,6 @@
 # * TEST_HELM set to build helm charts
 
 # for testing manually:
-# * SKIP_BUILD_HELM set to avoid bin/build-helm while running bin/test-helm-e2e
 # * SKIP_IMAGE set to avoid bin/build-image while running bin/up
 
 export DOCKER_IMAGE_TAG=${DOCKER_IMAGE_TAG:-dev}
@@ -41,7 +40,7 @@ replace_local_chart() {
   find helm/ -name "$chart*.tgz" -delete
   mkdir -p helm/cf-operator/charts/"$chart"
   cp -av "$localchartdir/$chart/helm/$chart" helm/cf-operator/charts/
-  echo -e "The cf-operator helm chart has been modified.\n Don't run bin/test-helm-e2e without setting SKIP_BUILD_HELM=1 to retain changes."
+  echo -e "The cf-operator helm chart has been modified."
 }
 
 if [ "$TEST_HELM" ]; then

--- a/bin/include/versioning
+++ b/bin/include/versioning
@@ -1,8 +1,12 @@
 #!/bin/bash
 
-GIT_ROOT=${GIT_ROOT:-$(git rev-parse --show-toplevel)}
+# This produces a semver compatible pre-release version number from "git
+# describe" output.
+# The ARTIFACT_VERSION is also compatible with docker. It will not contain any
+# build metadata, since docker can't understand a '+'.
+# If run on a dirty working tree, '-dirty' is added to the pre-release part.
+
 GIT_DESCRIBE=$(git describe --tags --long || (git tag -a v0.0.0 -m "tag v0.0.0"; git describe --tags --long))
-GIT_BRANCH=${GIT_BRANCH:-$(git name-rev --name-only HEAD)}
 
 GIT_COMMITS=$(echo "${GIT_DESCRIBE}" | awk -F - '{ print $2 }')
 GIT_SHA=$(echo "${GIT_DESCRIBE}" | awk -F - '{ print $3 }' )

--- a/bin/test-helm-e2e-storage
+++ b/bin/test-helm-e2e-storage
@@ -10,11 +10,6 @@ if [ -z ${TEST_NAMESPACE+x} ]; then
   export TEST_NAMESPACE
 fi
 
-# Build the required helm charts to run the cf-operator
-if [ -z "${SKIP_BUILD_HELM:-}" ]; then
-  ./bin/build-helm
-fi
-
 NODES=${NODES:-3}
 FLAKE_ATTEMPTS=${FLAKE_ATTEMPTS:-3}
 ginkgo \

--- a/bin/test-helm-e2e-upgrade
+++ b/bin/test-helm-e2e-upgrade
@@ -10,11 +10,6 @@ if [ -z ${TEST_NAMESPACE+x} ]; then
   export TEST_NAMESPACE
 fi
 
-# Build the required helm charts to run the cf-operator
-if [ -z "${SKIP_BUILD_HELM:-}" ]; then
-  ./bin/build-helm
-fi
-
 NODES=${NODES:-1}
 FLAKE_ATTEMPTS=${FLAKE_ATTEMPTS:-3}
 ginkgo \


### PR DESCRIPTION
The build-helm script will use a pre-release semver, unless RELEASE env var is set.

* add dependencies to Makefile targets
* remove call to bin/build-helm from test scripts


[#174254540](https://www.pivotaltracker.com/story/show/174254540)