### PR TITLE
Fix deployment name error message for unmanaged resources

### DIFF
--- a/pkg/kube/apis/boshdeployment/v1alpha1/types.go
+++ b/pkg/kube/apis/boshdeployment/v1alpha1/types.go
@@ -138,3 +138,9 @@ type BOSHDeploymentList struct {
 func (bdpl *BOSHDeployment) GetNamespacedName() string {
 	return fmt.Sprintf("%s/%s", bdpl.Namespace, bdpl.Name)
 }
+
+// HasDeploymentName returns true if the deployment name label is present in the set of labels
+func HasDeploymentName(l map[string]string) bool {
+	_, ok := l[LabelDeploymentName]
+	return ok
+}

--- a/pkg/kube/controllers/boshdeployment/status_controller.go
+++ b/pkg/kube/controllers/boshdeployment/status_controller.go
@@ -1,0 +1,71 @@
+package boshdeployment
+
+import (
+	"context"
+
+	qjv1a1 "code.cloudfoundry.org/quarks-job/pkg/kube/apis/quarksjob/v1alpha1"
+	bdv1 "code.cloudfoundry.org/quarks-operator/pkg/kube/apis/boshdeployment/v1alpha1"
+
+	qstsv1a1 "code.cloudfoundry.org/quarks-statefulset/pkg/kube/apis/quarksstatefulset/v1alpha1"
+	"code.cloudfoundry.org/quarks-utils/pkg/config"
+	"code.cloudfoundry.org/quarks-utils/pkg/ctxlog"
+	"code.cloudfoundry.org/quarks-utils/pkg/monitorednamespace"
+
+	"github.com/pkg/errors"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+// AddBDPLStatusReconcilers creates a new BDPL Status controller to update BDPL status.
+func AddBDPLStatusReconcilers(ctx context.Context, config *config.Config, mgr manager.Manager) error {
+	ctx = ctxlog.NewContextWithRecorder(ctx, "quarks-bdpl-status-reconciler", mgr.GetEventRecorderFor("quarks-bdpl-status-recorder"))
+	r := NewStatusQSTSReconciler(ctx, config, mgr)
+	rjobs := NewQJobStatusReconciler(ctx, config, mgr)
+
+	// Create a new controller for qsts
+	c, err := controller.New("quarks-bdpl-qsts-status-controller", mgr, controller.Options{
+		Reconciler:              r,
+		MaxConcurrentReconciles: config.MaxQuarksStatefulSetWorkers,
+	})
+	if err != nil {
+		return errors.Wrap(err, "Adding StatusQSTSReconciler controller to manager failed.")
+	}
+
+	// Create a new controller for qjobs
+	cjobs, err := controller.New("quarks-bdpl-qjobs-status-controller", mgr, controller.Options{
+		Reconciler:              rjobs,
+		MaxConcurrentReconciles: config.MaxQuarksStatefulSetWorkers,
+	})
+	if err != nil {
+		return errors.Wrap(err, "Adding StatusQJobsReconciler controller to manager failed.")
+	}
+
+	nsPred := monitorednamespace.NewNSPredicate(ctx, mgr.GetClient(), config.MonitoredID)
+
+	p := predicate.Funcs{
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			return bdv1.HasDeploymentName(e.MetaNew.GetLabels()) || bdv1.HasDeploymentName(e.MetaOld.GetLabels())
+		},
+		CreateFunc: func(e event.CreateEvent) bool {
+			return bdv1.HasDeploymentName(e.Meta.GetLabels())
+		},
+		GenericFunc: func(e event.GenericEvent) bool {
+			return false
+		},
+	}
+	err = c.Watch(&source.Kind{Type: &qstsv1a1.QuarksStatefulSet{}}, &handler.EnqueueRequestForObject{}, nsPred, p)
+	if err != nil {
+		return errors.Wrapf(err, "Watching QSTS in QuarksBDPLStatus controller failed.")
+	}
+
+	err = cjobs.Watch(&source.Kind{Type: &qjv1a1.QuarksJob{}}, &handler.EnqueueRequestForObject{}, nsPred, p)
+	if err != nil {
+		return errors.Wrapf(err, "Watching QJobs in QuarksBDPLStatus controller failed.")
+	}
+
+	return nil
+}

--- a/pkg/kube/controllers/boshdeployment/status_reconciler.go
+++ b/pkg/kube/controllers/boshdeployment/status_reconciler.go
@@ -10,21 +10,14 @@ import (
 	qstsv1a1 "code.cloudfoundry.org/quarks-statefulset/pkg/kube/apis/quarksstatefulset/v1alpha1"
 	"code.cloudfoundry.org/quarks-utils/pkg/config"
 	"code.cloudfoundry.org/quarks-utils/pkg/ctxlog"
-	"code.cloudfoundry.org/quarks-utils/pkg/monitorednamespace"
 
-	"github.com/pkg/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller"
-	"sigs.k8s.io/controller-runtime/pkg/event"
-	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
-	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
 const (
@@ -70,6 +63,121 @@ type ReconcileBoshDeploymentQJobStatus struct {
 	client client.Client
 	scheme *runtime.Scheme
 	config *config.Config
+}
+
+// Reconcile reads that state of QuarksJobs and QuarksStatefulSets and updates the bosh deployment status accordingly.
+// The Controller will requeue the Request to be processed again if the returned error is non-nil or
+// Result.Requeue is true, otherwise upon completion it will remove the work from the queue.
+func (r *ReconcileBoshDeploymentQJobStatus) Reconcile(request reconcile.Request) (reconcile.Result, error) {
+
+	// Fetch the QuarksStatefulSet we need to reconcile
+	qJob := &qjv1a1.QuarksJob{}
+
+	// Set the ctx to be Background, as the top-level context for incoming requests.
+	ctx, cancel := context.WithTimeout(r.ctx, r.config.CtxTimeOut)
+	defer cancel()
+
+	ctxlog.Info(ctx, "Reconciling Bosh Deployment from qjob ", request.NamespacedName)
+	err := r.client.Get(ctx, request.NamespacedName, qJob)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			// Request object not found, could have been deleted after reconcile request.
+			// Owned objects are automatically garbage collected. For additional cleanup logic use finalizers.
+			// Return and don't requeue
+			ctxlog.Debug(ctx, "Skip qJob reconcile: qJob not found")
+			return reconcile.Result{}, nil
+		}
+
+		// Error reading the object - requeue the request.
+		return reconcile.Result{}, err
+	}
+	deploymentName, ok := qJob.GetLabels()[bdv1.LabelDeploymentName]
+	if !ok {
+		ctxlog.WithEvent(qJob, "LabelMissingError").Infof(ctx, "There's no label for a BoshDeployment name on the qjob '%s'", request.NamespacedName)
+		return reconcile.Result{Requeue: false}, nil
+	}
+	bdpl := &bdv1.BOSHDeployment{}
+	err = r.client.Get(ctx, types.NamespacedName{Namespace: request.Namespace, Name: deploymentName}, bdpl)
+	if err != nil {
+		return reconcile.Result{Requeue: false},
+			ctxlog.WithEvent(qJob, "GetBOSHDeployment").Errorf(ctx, "Failed to get BoshDeployment instance '%s/%s': %v", request.Namespace, deploymentName, err)
+	}
+
+	toUpdate, err := resolveDeploymentState(r.ctx, r.client, bdpl)
+	if err != nil {
+		return reconcile.Result{Requeue: false}, err
+	}
+
+	if toUpdate {
+		now := metav1.Now()
+		bdpl.Status.StateTimestamp = &now
+
+		err = r.client.Status().Update(ctx, bdpl)
+		if err != nil {
+			return reconcile.Result{Requeue: false}, ctxlog.WithEvent(bdpl, "UpdateStatusError").Errorf(ctx, "Failed to update status on BDPL '%s' (%v): %s", request.NamespacedName, bdpl.ResourceVersion, err)
+		}
+	}
+
+	return reconcile.Result{}, nil
+}
+
+// Reconcile reads that state of QuarksJobs and QuarksStatefulSets and updates the bosh deployment status accordingly.
+// and makes changes based on the state read and what is in the QuarksStatefulSet.Spec
+// Note:
+// The Controller will requeue the Request to be processed again if the returned error is non-nil or
+// Result.Requeue is true, otherwise upon completion it will remove the work from the queue.
+func (r *ReconcileBoshDeploymentQSTSStatus) Reconcile(request reconcile.Request) (reconcile.Result, error) {
+
+	// Fetch the QuarksStatefulSet we need to reconcile
+	qStatefulSet := &qstsv1a1.QuarksStatefulSet{}
+
+	// Set the ctx to be Background, as the top-level context for incoming requests.
+	ctx, cancel := context.WithTimeout(r.ctx, r.config.CtxTimeOut)
+	defer cancel()
+
+	ctxlog.Info(ctx, "Reconciling QuarksStatefulSet ", request.NamespacedName)
+	err := r.client.Get(ctx, request.NamespacedName, qStatefulSet)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			// Request object not found, could have been deleted after reconcile request.
+			// Owned objects are automatically garbage collected. For additional cleanup logic use finalizers.
+			// Return and don't requeue
+			ctxlog.Debug(ctx, "Skip QuarksStatefulSet reconcile: QuarksStatefulSet not found")
+			return reconcile.Result{}, nil
+		}
+
+		// Error reading the object - requeue the request.
+		return reconcile.Result{}, err
+	}
+
+	deploymentName, ok := qStatefulSet.GetLabels()[bdv1.LabelDeploymentName]
+	if !ok {
+		ctxlog.WithEvent(qStatefulSet, "LabelMissingError").Infof(ctx, "There's no label for a BoshDeployment name on the QSTS '%s'", request.NamespacedName)
+		return reconcile.Result{Requeue: false}, nil
+	}
+
+	bdpl := &bdv1.BOSHDeployment{}
+	err = r.client.Get(ctx, types.NamespacedName{Namespace: request.Namespace, Name: deploymentName}, bdpl)
+	if err != nil {
+		return reconcile.Result{Requeue: false},
+			ctxlog.WithEvent(qStatefulSet, "GetBOSHDeployment").Errorf(ctx, "Failed to get BoshDeployment instance '%s/%s': %v", request.Namespace, deploymentName, err)
+	}
+
+	toUpdate, err := resolveDeploymentState(r.ctx, r.client, bdpl)
+	if err != nil {
+		return reconcile.Result{Requeue: false}, err
+	}
+
+	if toUpdate {
+		now := metav1.Now()
+		bdpl.Status.StateTimestamp = &now
+		err = r.client.Status().Update(ctx, bdpl)
+		if err != nil {
+			return reconcile.Result{Requeue: false}, ctxlog.WithEvent(bdpl, "UpdateStatusError").Errorf(ctx, "Failed to update status on BDPL '%s' (%v): %s", request.NamespacedName, bdpl.ResourceVersion, err)
+		}
+	}
+
+	return reconcile.Result{}, nil
 }
 
 func resolveDeploymentState(ctx context.Context, client client.Client, bdpl *bdv1.BOSHDeployment) (bool, error) {
@@ -155,170 +263,4 @@ func resolveDeploymentState(ctx context.Context, client client.Client, bdpl *bdv
 		toUpdate = true
 	}
 	return toUpdate, nil
-}
-
-// Reconcile reads that state of QuarksJobs and QuarksStatefulSets and updates the bosh deployment status accordingly.
-// The Controller will requeue the Request to be processed again if the returned error is non-nil or
-// Result.Requeue is true, otherwise upon completion it will remove the work from the queue.
-func (r *ReconcileBoshDeploymentQJobStatus) Reconcile(request reconcile.Request) (reconcile.Result, error) {
-
-	// Fetch the QuarksStatefulSet we need to reconcile
-	qJob := &qjv1a1.QuarksJob{}
-
-	// Set the ctx to be Background, as the top-level context for incoming requests.
-	ctx, cancel := context.WithTimeout(r.ctx, r.config.CtxTimeOut)
-	defer cancel()
-
-	ctxlog.Info(ctx, "Reconciling Bosh Deployment from qjob ", request.NamespacedName)
-	err := r.client.Get(ctx, request.NamespacedName, qJob)
-	if err != nil {
-		if apierrors.IsNotFound(err) {
-			// Request object not found, could have been deleted after reconcile request.
-			// Owned objects are automatically garbage collected. For additional cleanup logic use finalizers.
-			// Return and don't requeue
-			ctxlog.Debug(ctx, "Skip qJob reconcile: qJob not found")
-			return reconcile.Result{}, nil
-		}
-
-		// Error reading the object - requeue the request.
-		return reconcile.Result{}, err
-	}
-	deploymentName, ok := qJob.GetLabels()[bdv1.LabelDeploymentName]
-	if !ok {
-		ctxlog.WithEvent(qJob, "LabelMissingError").Infof(ctx, "There's no label for a BoshDeployment name on the QSTS '%s'", request.NamespacedName)
-		return reconcile.Result{Requeue: false}, nil
-	}
-	bdpl := &bdv1.BOSHDeployment{}
-	err = r.client.Get(ctx, types.NamespacedName{Namespace: request.Namespace, Name: deploymentName}, bdpl)
-	if err != nil {
-		return reconcile.Result{Requeue: false},
-			ctxlog.WithEvent(qJob, "GetBOSHDeployment").Errorf(ctx, "Failed to get BoshDeployment instance '%s/%s': %v", request.Namespace, deploymentName, err)
-	}
-
-	toUpdate, err := resolveDeploymentState(r.ctx, r.client, bdpl)
-	if err != nil {
-		return reconcile.Result{Requeue: false}, err
-	}
-
-	if toUpdate {
-		now := metav1.Now()
-		bdpl.Status.StateTimestamp = &now
-
-		err = r.client.Status().Update(ctx, bdpl)
-		if err != nil {
-			return reconcile.Result{Requeue: false}, ctxlog.WithEvent(bdpl, "UpdateStatusError").Errorf(ctx, "Failed to update status on BDPL '%s' (%v): %s", request.NamespacedName, bdpl.ResourceVersion, err)
-		}
-	}
-
-	return reconcile.Result{}, nil
-}
-
-// Reconcile reads that state of QuarksJobs and QuarksStatefulSets and updates the bosh deployment status accordingly.
-// and makes changes based on the state read and what is in the QuarksStatefulSet.Spec
-// Note:
-// The Controller will requeue the Request to be processed again if the returned error is non-nil or
-// Result.Requeue is true, otherwise upon completion it will remove the work from the queue.
-func (r *ReconcileBoshDeploymentQSTSStatus) Reconcile(request reconcile.Request) (reconcile.Result, error) {
-
-	// Fetch the QuarksStatefulSet we need to reconcile
-	qStatefulSet := &qstsv1a1.QuarksStatefulSet{}
-
-	// Set the ctx to be Background, as the top-level context for incoming requests.
-	ctx, cancel := context.WithTimeout(r.ctx, r.config.CtxTimeOut)
-	defer cancel()
-
-	ctxlog.Info(ctx, "Reconciling QuarksStatefulSet ", request.NamespacedName)
-	err := r.client.Get(ctx, request.NamespacedName, qStatefulSet)
-	if err != nil {
-		if apierrors.IsNotFound(err) {
-			// Request object not found, could have been deleted after reconcile request.
-			// Owned objects are automatically garbage collected. For additional cleanup logic use finalizers.
-			// Return and don't requeue
-			ctxlog.Debug(ctx, "Skip QuarksStatefulSet reconcile: QuarksStatefulSet not found")
-			return reconcile.Result{}, nil
-		}
-
-		// Error reading the object - requeue the request.
-		return reconcile.Result{}, err
-	}
-
-	deploymentName, ok := qStatefulSet.GetLabels()[bdv1.LabelDeploymentName]
-	if !ok {
-		return reconcile.Result{Requeue: false},
-			ctxlog.WithEvent(qStatefulSet, "LabelMissingError").Errorf(ctx, "There's no label for a BoshDeployment name on the QSTS '%s'", request.NamespacedName)
-	}
-
-	bdpl := &bdv1.BOSHDeployment{}
-	err = r.client.Get(ctx, types.NamespacedName{Namespace: request.Namespace, Name: deploymentName}, bdpl)
-	if err != nil {
-		return reconcile.Result{Requeue: false},
-			ctxlog.WithEvent(qStatefulSet, "GetBOSHDeployment").Errorf(ctx, "Failed to get BoshDeployment instance '%s/%s': %v", request.Namespace, deploymentName, err)
-	}
-
-	toUpdate, err := resolveDeploymentState(r.ctx, r.client, bdpl)
-	if err != nil {
-		return reconcile.Result{Requeue: false}, err
-	}
-
-	if toUpdate {
-		now := metav1.Now()
-		bdpl.Status.StateTimestamp = &now
-		err = r.client.Status().Update(ctx, bdpl)
-		if err != nil {
-			return reconcile.Result{Requeue: false}, ctxlog.WithEvent(bdpl, "UpdateStatusError").Errorf(ctx, "Failed to update status on BDPL '%s' (%v): %s", request.NamespacedName, bdpl.ResourceVersion, err)
-		}
-	}
-
-	return reconcile.Result{}, nil
-}
-
-// AddBDPLStatusReconciler creates a new BDPL Status controller to update BDPL status.
-func AddBDPLStatusReconciler(ctx context.Context, config *config.Config, mgr manager.Manager) error {
-	ctx = ctxlog.NewContextWithRecorder(ctx, "quarks-bdpl-status-reconciler", mgr.GetEventRecorderFor("quarks-bdpl-status-recorder"))
-	r := NewStatusQSTSReconciler(ctx, config, mgr)
-	rjobs := NewQJobStatusReconciler(ctx, config, mgr)
-
-	// Create a new controller
-	c, err := controller.New("quarks-bdpl-qsts-status-controller", mgr, controller.Options{
-		Reconciler:              r,
-		MaxConcurrentReconciles: config.MaxQuarksStatefulSetWorkers,
-	})
-	if err != nil {
-		return errors.Wrap(err, "Adding StatusQSTSReconciler controller to manager failed.")
-	}
-
-	// Create a new controller
-	cjobs, err := controller.New("quarks-bdpl-qjobs-status-controller", mgr, controller.Options{
-		Reconciler:              rjobs,
-		MaxConcurrentReconciles: config.MaxQuarksStatefulSetWorkers,
-	})
-	if err != nil {
-		return errors.Wrap(err, "Adding StatusQJobsReconciler controller to manager failed.")
-	}
-
-	nsPred := monitorednamespace.NewNSPredicate(ctx, mgr.GetClient(), config.MonitoredID)
-
-	// doamins are watched on updates too to get status changes
-	certPred := predicate.Funcs{
-		UpdateFunc: func(e event.UpdateEvent) bool {
-			return true
-		},
-		CreateFunc: func(e event.CreateEvent) bool {
-			return true
-		},
-		GenericFunc: func(e event.GenericEvent) bool {
-			return false
-		},
-	}
-	err = c.Watch(&source.Kind{Type: &qstsv1a1.QuarksStatefulSet{}}, &handler.EnqueueRequestForObject{}, nsPred, certPred)
-	if err != nil {
-		return errors.Wrapf(err, "Watching QSTS in QuarksBDPLStatus controller failed.")
-	}
-
-	err = cjobs.Watch(&source.Kind{Type: &qjv1a1.QuarksJob{}}, &handler.EnqueueRequestForObject{}, nsPred, certPred)
-	if err != nil {
-		return errors.Wrapf(err, "Watching QJobs in QuarksBDPLStatus controller failed.")
-	}
-
-	return nil
 }

--- a/pkg/kube/controllers/boshdeployment/withops_controller.go
+++ b/pkg/kube/controllers/boshdeployment/withops_controller.go
@@ -111,7 +111,7 @@ func AddWithOps(ctx context.Context, config *config.Config, mgr manager.Manager)
 		ToRequests: handler.ToRequestsFunc(func(a handler.MapObject) []reconcile.Request {
 			s := a.Object.(*corev1.Secret)
 			result := []reconcile.Request{
-				reconcile.Request{
+				{
 					NamespacedName: types.NamespacedName{
 						Name:      bdv1.DeploymentSecretTypeManifestWithOps.String(),
 						Namespace: s.Namespace,
@@ -144,8 +144,7 @@ func isWithOpsSecret(secret *corev1.Secret) bool {
 
 func isDeploymentExplicitSecret(secret *corev1.Secret) bool {
 	secretLabels := secret.GetLabels()
-	_, ok := secretLabels[bdv1.LabelDeploymentName]
-	if !ok {
+	if !bdv1.HasDeploymentName(secretLabels) {
 		return false
 	}
 	value, ok := secretLabels[qsv1a1.LabelKind]

--- a/pkg/kube/controllers/controllers.go
+++ b/pkg/kube/controllers/controllers.go
@@ -42,7 +42,7 @@ var addToManagerFuncs = []func(context.Context, *config.Config, manager.Manager)
 	boshdeployment.AddDeployment,
 	boshdeployment.AddBPM,
 	boshdeployment.AddWithOps,
-	boshdeployment.AddBDPLStatusReconciler,
+	boshdeployment.AddBDPLStatusReconcilers,
 	quarksstatefulset.AddQuarksStatefulSet,
 	quarksstatefulset.AddQuarksStatefulSetStatus,
 	statefulset.AddStatefulSetRollout,


### PR DESCRIPTION
BDPL status reconciler should not give error messages for unmanaged
resources.

Doesn't need to reconcile qjobs and qsts without a deployment label.
Split controllers into separate file for readability.