### PR TITLE
Change the coredns image source and tag

### DIFF
--- a/deploy/helm/cf-operator/values.yaml
+++ b/deploy/helm/cf-operator/values.yaml
@@ -44,7 +44,7 @@ operator:
     # port the webhook server listens on
     port: "2999"
   # boshDNSDockerImage is the docker image used for emulating bosh DNS (a CoreDNS image).
-  boshDNSDockerImage: "registry.opensuse.org/cloud/platform/quarks/images/images/coredns@sha256:e5a6afe73d0823b45e7faaa71574bb1a596c53f1e1f95f693acbb850058d09f6"
+  boshDNSDockerImage: "cfcontainerization/coredns:0.1.0-1.6.7-bp152.1.19"
 
 # serviceAccount contains the configuration
 # values of the service account used by cf-operator.


### PR DESCRIPTION
There is a problem with the CAP release tool, as it can't handle tags.
However we only get a SHA from OBS: https://jira.suse.com/browse/CAP-1598

Additionally, we're told registry.opensuse.org cannot store multiple
versions, so the SHA would disappear once a new version is pushed. All
registry.opensuse.org images have to be copied elsewhere.

Switching back to dockerhub and tag for now.
