### PR TITLE
Remove spec-index arg from template-render command

### DIFF
--- a/e2e/cli/cli_test.go
+++ b/e2e/cli/cli_test.go
@@ -193,7 +193,6 @@ var _ = Describe("CLI", func() {
       --pod-ip string                \(POD_IP\) pod IP
       --pod-ordinal int              \(POD_ORDINAL\) pod ordinal \(default -1\)
       --replicas int                 \(REPLICAS\) number of replicas \(default -1\)
-      --spec-index int               \(SPEC_INDEX\) index of the instance spec \(default -1\)
 `))
 		})
 

--- a/e2e/cli/util_render_template_test.go
+++ b/e2e/cli/util_render_template_test.go
@@ -34,7 +34,7 @@ var _ = Describe("render-template", func() {
 			"-m", manifestPath,
 			"-j", assetPath,
 			"-g", "log-api",
-			"--spec-index", "0",
+			"--az-index", "1",
 			"-d", tmpDir,
 			"--pod-ip", "10.10.50.50",
 			"--replicas", "2",


### PR DESCRIPTION
Couldn't find any usage of this arg in quarks-operator

[#174661471](https://www.pivotaltracker.com/story/show/174661471)
