### PR TITLE
feat: pre-upgrade hook for deleting dm qjobs

### DIFF
--- a/deploy/helm/cf-operator/templates/pre-upgrade-hook.yaml
+++ b/deploy/helm/cf-operator/templates/pre-upgrade-hook.yaml
@@ -1,0 +1,97 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ printf "%s-pre-upgrade" .Release.Name | quote }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/name: {{ include "cf-operator.fullname" . }}
+    app.kubernetes.io/version: {{ default .Chart.Version .Chart.AppVersion | quote }}
+    helm.sh/chart: {{ include "cf-operator.chart" . }}
+  annotations:
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-weight: "-2"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ printf "%s-pre-upgrade-delete-dm" .Release.Name | quote }}
+  namespace: {{ .Values.global.singleNamespace.name | quote }}
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/name: {{ include "cf-operator.fullname" . }}
+    app.kubernetes.io/version: {{ default .Chart.Version .Chart.AppVersion | quote }}
+    helm.sh/chart: {{ include "cf-operator.chart" . }}
+  annotations:
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-weight: "-2"
+rules:
+- apiGroups: [quarks.cloudfoundry.org]
+  resources: [quarksjobs]
+  resourceNames: [dm]
+  verbs: [delete]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ printf "%s-pre-upgrade-delete-dm" .Release.Name | quote }}
+  namespace: {{ .Values.global.singleNamespace.name | quote }}
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/name: {{ include "cf-operator.fullname" . }}
+    app.kubernetes.io/version: {{ default .Chart.Version .Chart.AppVersion | quote }}
+    helm.sh/chart: {{ include "cf-operator.chart" . }}
+  annotations:
+    rbac.authorization.kubernetes.io/autoupdate: "true"
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-weight: "-2"
+roleRef:
+  kind: Role
+  name: {{ printf "%s-pre-upgrade-delete-dm" .Release.Name | quote }}
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: {{ printf "%s-pre-upgrade" .Release.Name | quote }}
+  namespace: {{ .Release.Namespace | quote }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ printf "%s-pre-upgrade" .Release.Name | quote }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/name: {{ include "cf-operator.fullname" . }}
+    app.kubernetes.io/version: {{ default .Chart.Version .Chart.AppVersion | quote }}
+    helm.sh/chart: {{ include "cf-operator.chart" . }}
+  annotations:
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-weight: "-1"
+spec:
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/instance: {{ .Release.Name | quote }}
+        app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+        app.kubernetes.io/name: {{ include "cf-operator.fullname" . }}
+        app.kubernetes.io/version: {{ default .Chart.Version .Chart.AppVersion | quote }}
+        helm.sh/chart: {{ include "cf-operator.chart" . }}
+    spec:
+      serviceAccountName: {{ printf "%s-pre-upgrade" .Release.Name | quote }}
+      restartPolicy: Never
+      containers:
+      - name: pre-upgrade
+        image: {{ .Values.operator.preUpgradeHookDockerImage | quote }}
+        imagePullPolicy: IfNotPresent
+        args:
+        - kubectl
+        - delete
+        - quarksjobs.quarks.cloudfoundry.org
+        - --ignore-not-found
+        - {{ printf "--namespace=%s" .Values.global.singleNamespace.name | squote }}
+        - dm

--- a/deploy/helm/cf-operator/values.yaml
+++ b/deploy/helm/cf-operator/values.yaml
@@ -45,6 +45,7 @@ operator:
     port: "2999"
   # boshDNSDockerImage is the docker image used for emulating bosh DNS (a CoreDNS image).
   boshDNSDockerImage: "cfcontainerization/coredns:0.1.0-1.6.7-bp152.1.19"
+  preUpgradeHookDockerImage: "ghcr.io/cfcontainerizationbot/kubecf-kubectl:v1.19.2"
 
 # serviceAccount contains the configuration
 # values of the service account used by cf-operator.


### PR DESCRIPTION
At some point, quarks-operator stopped relying on dm qjobs, leaving them
behind. This is problematic when upgrading the quarks-operator on top of
a KubeCF that still has this qjob around.

This pre-upgrade hook will make sure to delete it in the namespace
quarks-operator is watching, preventing it from getting incorrectly
triggered.

Fixes https://github.com/cloudfoundry-incubator/quarks-operator/issues/1170.