### PR TITLE
fix: add preUpgradeHookDockerImage to imagelist

### DIFF
--- a/bin/build-helm
+++ b/bin/build-helm
@@ -52,6 +52,7 @@ ruby -ryaml > "$imagelist" <<EOF
   image = values['image']
   puts "#{image['org']}/#{image['repository']}:#{image['tag']}"
   puts values['operator']['boshDNSDockerImage']
+  puts values['operator']['preUpgradeHookDockerImage']
 
   values = YAML.load_file('$quarks_job_values_file')
   image = values['image']


### PR DESCRIPTION
Fixes missing image in `imagelist.txt`, otherwise cap release would miss it from copying.

After the change, the new tarball has the image:
```cat /tmp/test/cf-operator/imagelist.txt 
cfcontainerization/cf-operator:v6.1.17-dirty-0.gec409fd7
cfcontainerization/coredns:0.1.0-1.6.7-bp152.1.19
ghcr.io/cfcontainerizationbot/kubecf-kubectl:v1.19.2
cfcontainerization/quarks-job:v1.0.206
cfcontainerization/quarks-secret:v1.0.744
```

cc @viovanov 

## Checklist:

Check item if necessary.

- [ ] Review PRs of changed Quarks dependencies
- [ ] Update this PR after the release of Quarks dependencies
