### PR TITLE
fix RenderJobTemplate specIndex error

### DIFF
--- a/pkg/bosh/manifest/cmd_render_job_tmpls.go
+++ b/pkg/bosh/manifest/cmd_render_job_tmpls.go
@@ -97,7 +97,7 @@ func RenderJobTemplates(
 				if len(currentInstanceGroup.AZs) > 0 {
 					for azIndex, az := range currentInstanceGroup.AZs {
 						if instance.AZ == az {
-							if instance.Instance + azIndex*10000 == specIndex {
+							if instance.Instance+azIndex*10000 == specIndex {
 								currentJobInstance = &instance
 								break
 							}

--- a/pkg/bosh/manifest/cmd_render_job_tmpls.go
+++ b/pkg/bosh/manifest/cmd_render_job_tmpls.go
@@ -94,9 +94,23 @@ func RenderJobTemplates(
 			// Find job instance that's being rendered
 			var currentJobInstance *JobInstance
 			for _, instance := range job.Properties.Quarks.Instances {
-				if instance.Index == specIndex {
-					currentJobInstance = &instance
-					break
+				if len(currentInstanceGroup.AZs) > 0 {
+					for azIndex, az := range currentInstanceGroup.AZs {
+						if instance.AZ == az {
+							if instance.Instance + azIndex*10000 == specIndex {
+								currentJobInstance = &instance
+								break
+							}
+						}
+					}
+					if currentJobInstance != nil {
+						break
+					}
+				} else {
+					if instance.Index == specIndex {
+						currentJobInstance = &instance
+						break
+					}
 				}
 			}
 			if currentJobInstance == nil {

--- a/pkg/bosh/manifest/cmd_render_job_tmpls_test.go
+++ b/pkg/bosh/manifest/cmd_render_job_tmpls_test.go
@@ -158,10 +158,10 @@ var _ = Describe("Trender", func() {
 			deploymentManifest = assetPath + "/ig-resolved.redis.yml"
 			instanceGroupName = "redis-slave"
 
-			// By using index 1, we can make sure that an evaluation of spec.bootstrap
+			// By using non-zero index , we can make sure that an evaluation of spec.bootstrap
 			// will return false. See https://bosh.io/docs/jobs/#properties-spec for
 			// more information.
-			index = 1
+			index = 10000
 			podIP = net.ParseIP("172.17.0.13")
 			replicas = 1
 		})

--- a/testing/assets/ig-resolved.redis.yml
+++ b/testing/assets/ig-resolved.redis.yml
@@ -2,7 +2,7 @@ name: redis-deployment
 director_uuid: ""
 instance_groups:
 - name: redis-slave
-  instances: 1
+  instances: 2
   azs: [z1, z2]
   jobs:
   - name: redis-server
@@ -20,10 +20,24 @@ instance_groups:
               name: redis-slave-redis-server
               networks: null
             - address: foo-deployment-redis-slave-1
-              az: z2
+              az: z1
               bootstrap: false
               index: 1
+              instance: 1
+              name: redis-slave-redis-server
+              networks: null
+            - address: foo-deployment-redis-slave-2
+              az: z2
+              bootstrap: false
+              index: 2
               instance: 0
+              name: redis-slave-redis-server
+              networks: null
+            - address: foo-deployment-redis-slave-3
+              az: z2
+              bootstrap: false
+              index: 3
+              instance: 1
               name: redis-slave-redis-server
               networks: null
             properties:
@@ -39,10 +53,24 @@ instance_groups:
           name: redis-slave-redis-server
           networks: null
         - address: foo-deployment-redis-slave-1
-          az: z2
+          az: z1
           bootstrap: false
           index: 1
+          instance: 1
+          name: redis-slave-redis-server
+          networks: null
+        - address: foo-deployment-redis-slave-2
+          az: z2
+          bootstrap: false
+          index: 2
           instance: 0
+          name: redis-slave-redis-server
+          networks: null
+        - address: foo-deployment-redis-slave-3
+          az: z2
+          bootstrap: false
+          index: 3
+          instance: 1
           name: redis-slave-redis-server
           networks: null
         bpm:

--- a/testing/assets/ig-resolved.redis.yml
+++ b/testing/assets/ig-resolved.redis.yml
@@ -2,7 +2,7 @@ name: redis-deployment
 director_uuid: ""
 instance_groups:
 - name: redis-slave
-  instances: 2
+  instances: 1
   azs: [z1, z2]
   jobs:
   - name: redis-server
@@ -20,24 +20,10 @@ instance_groups:
               name: redis-slave-redis-server
               networks: null
             - address: foo-deployment-redis-slave-1
-              az: z1
+              az: z2
               bootstrap: false
               index: 1
-              instance: 1
-              name: redis-slave-redis-server
-              networks: null
-            - address: foo-deployment-redis-slave-2
-              az: z2
-              bootstrap: false
-              index: 2
               instance: 0
-              name: redis-slave-redis-server
-              networks: null
-            - address: foo-deployment-redis-slave-3
-              az: z2
-              bootstrap: false
-              index: 3
-              instance: 1
               name: redis-slave-redis-server
               networks: null
             properties:
@@ -53,24 +39,10 @@ instance_groups:
           name: redis-slave-redis-server
           networks: null
         - address: foo-deployment-redis-slave-1
-          az: z1
+          az: z2
           bootstrap: false
           index: 1
-          instance: 1
-          name: redis-slave-redis-server
-          networks: null
-        - address: foo-deployment-redis-slave-2
-          az: z2
-          bootstrap: false
-          index: 2
           instance: 0
-          name: redis-slave-redis-server
-          networks: null
-        - address: foo-deployment-redis-slave-3
-          az: z2
-          bootstrap: false
-          index: 3
-          instance: 1
           name: redis-slave-redis-server
           networks: null
         bpm:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fix kubecf deploy failure mentioned in https://github.com/cloudfoundry-incubator/quarks-operator/issues/1206

<!--- Describe your changes in detail -->
The issue was found whey I tried to deploy kubecf 2.5.8 with multi_az enabled, only one zone pods get running, the others fail with error "no job instance found for spec index '10000'".

I find that the calculation of  `specIndex` was changed since commit
https://github.com/cloudfoundry-incubator/quarks-operator/commit/c6ba7e7391a516f04f676a70e80bf5f488061f49#diff-8d311956cef69b8982593414c29b44676d3e74d69a0e3321d346d8caf56f088c

And when multi_az enabled, below comparison 
https://github.com/cloudfoundry-incubator/quarks-operator/blob/b31c0c41415cee1c2438025fc18f0b3ef126947a/pkg/bosh/manifest/cmd_render_job_tmpls.go#L97
will never find the matching instance and then report a deployment failure.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue or belongs to a story, please add a link here. -->
https://github.com/cloudfoundry-incubator/quarks-operator/issues/1206

## Checklist:

Check item if necessary.

- [ ] Review PRs of changed Quarks dependencies
- [ ] Update this PR after the release of Quarks dependencies
