### PR TITLE
Run on PRs from forks

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,9 +6,6 @@ on:
   # nightly
   schedule:
     - cron:  '0 0 * * *'
-  # run for labeled PRs
-  pull_request_target:
-    types: [labeled]
 
 env:
   GOPROXY: "https://proxy.golang.org"
@@ -19,30 +16,11 @@ env:
   DOCKER_RELEASE_REPOSITORY: quarks-operator
 
 jobs:
-
-  # The first thing we do is to check that the PR has the pr-test-queue label
-  # If it doesn't have it, the flow stops. If it does, we remove it (approval is good for one run only).
-  dequeue:
-    name: dequeue
-    runs-on: ubuntu-20.04
-
-    if: contains(github.event.pull_request.labels.*.name, 'pr-test-queue') ||
-      github.repository == 'cloudfoundry-incubator/quarks-operator' &&
-      startsWith( github.ref, 'refs/heads/' ) ||
-      startsWith( github.ref, 'refs/tags/' )
-
-    # Also make this job succeed if label can't be deleted
-    continue-on-error: true
-
-    steps:
-      - uses: actions-ecosystem/action-remove-labels@556e306
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          labels: pr-test-queue
-
   unit-tests:
-    needs: [dequeue]
     runs-on: ubuntu-latest
+
+    # Cannot run for pushes in forked repos, without adapting this workflow
+    if: github.repository == 'cloudfoundry-incubator/quarks-operator'
 
     steps:
     - name: Set up Go

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,0 +1,218 @@
+name: run-pr-tests
+
+# Note: Don't expose secrets to scripts from the repo, only the workflow definition is from master
+
+on:
+  # run for labeled PRs from forks
+  pull_request_target:
+    types: [labeled]
+
+env:
+  GOPROXY: "https://proxy.golang.org"
+  DOCKER_IMAGE_ORG: ghcr.io/cfcontainerizationbot
+  DOCKER_IMAGE_REPOSITORY: quarks-operator-dev
+  DOCKER_IMAGE_TAG: "${{ github.sha }}"
+
+jobs:
+  # The first thing we do is to check that the PR has the pr-test-queue label
+  # If it doesn't have it, the flow stops. If it does, we remove it (approval is good for one run only).
+  dequeue:
+    name: dequeue
+    runs-on: ubuntu-20.04
+
+    # run for PRs with the 'pr-test-queue' label, opened from forks
+    if: github.repository != 'cloudfoundry-incubator/quarks-operator' &&
+      contains(github.event.pull_request.labels.*.name, 'pr-test-queue')
+
+    steps:
+      - uses: actions-ecosystem/action-remove-labels@556e306
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          labels: pr-test-queue
+
+  unit-tests:
+    needs: [dequeue]
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.15.1
+    - name: Checkout forked repository
+      uses: actions/checkout@v2
+      with:
+        ref: ${{github.event.pull_request.head.ref}}
+        repository: ${{github.event.pull_request.head.repo.full_name}}
+    - uses: actions/cache@v1
+      with:
+        path: ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
+    - name: Install dependencies
+      run: |
+        sudo gem install bosh-template
+        go install github.com/onsi/ginkgo/ginkgo
+        go get -u golang.org/x/lint/golint
+        curl -LO https://github.com/dominikh/go-tools/releases/download/2020.1.3/staticcheck_linux_amd64.tar.gz
+        sudo tar xfz staticcheck_linux_amd64.tar.gz --strip-component 1 -C $GOPATH/bin staticcheck/staticcheck
+    - name: Install shared tools
+      run: |
+        bin/tools
+    - name: Run lint
+      run: |
+        go list ./... | xargs go vet
+    - name: Run unit tests
+      run: |
+        bin/test-unit
+
+  dockerbuild:
+    needs: [unit-tests]
+    runs-on: ubuntu-16.04
+
+    steps:
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.15.1
+    - name: Checkout forked repository
+      uses: actions/checkout@v2
+      with:
+        ref: ${{github.event.pull_request.head.ref}}
+        repository: ${{github.event.pull_request.head.repo.full_name}}
+    - uses: actions/cache@v1
+      with:
+        path: ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
+    - name: Install shared tools
+      run: |
+        bin/tools
+        git config user.email "no-reply@quarks.cloudfoundry.org"
+        git config user.name "$GITHUB_ACTOR"
+    - name: Prepare docker build
+      run: |
+        go mod vendor
+    - uses: whoan/docker-build-with-cache-action@v5
+      with:
+        username: cfcontainerizationbot
+        # container registry personal access token
+        password: "${{ secrets.CR_PAT }}"
+        registry: "${{ env.DOCKER_IMAGE_ORG }}"
+        image_name: "${{ env.DOCKER_IMAGE_REPOSITORY }}"
+        image_tag: "${{ env.DOCKER_IMAGE_TAG }}"
+
+  e2e-tests:
+    needs: [dockerbuild]
+    runs-on: ubuntu-16.04
+    strategy:
+      matrix:
+        kubernetes_version: [v1.14.10,v1.16.4,v1.18.0]
+
+    steps:
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.15.1
+    - name: Checkout forked repository
+      uses: actions/checkout@v2
+      with:
+        ref: ${{github.event.pull_request.head.ref}}
+        repository: ${{github.event.pull_request.head.repo.full_name}}
+    - uses: actions/cache@v1
+      with:
+        path: ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
+    - name: Install Go dependencies
+      run: |
+        sudo gem install bosh-template
+        go install github.com/onsi/ginkgo/ginkgo
+    - name: Install shared tools
+      run: |
+        bin/tools
+        git config user.email "no-reply@quarks.cloudfoundry.org"
+        git config user.name "$GITHUB_ACTOR"
+    - name: Create k8s Kind Cluster
+      uses: engineerd/setup-kind@v0.4.0
+      with:
+       config: .github/kind-config.yaml
+       version: v0.7.0
+       image: kindest/node:${{matrix.kubernetes_version}}
+
+    - name: Run cluster tests
+      run: |
+        bin/build-helm
+        bin/test-cli-e2e
+        bin/test-helm-e2e
+        bin/test-helm-e2e-storage
+        bin/test-helm-e2e-upgrade
+      env:
+        NODES: "3"
+        OPERATOR_TEST_STORAGE_CLASS: "standard"
+        PROJECT: "quarks-operator"
+        CF_OPERATOR_WEBHOOK_SERVICE_HOST: 172.17.0.1
+    - uses: actions/upload-artifact@v2
+      if: success()
+      with:
+        name: helm chart
+        path: "helm/quarks-*.tgz"
+
+  integration-tests:
+    needs: [dockerbuild]
+    runs-on: ubuntu-16.04
+    strategy:
+      matrix:
+        kubernetes_version: [v1.14.10,v1.16.4,v1.18.0]
+
+    steps:
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.15.1
+    - name: Checkout forked repository
+      uses: actions/checkout@v2
+      with:
+        ref: ${{github.event.pull_request.head.ref}}
+        repository: ${{github.event.pull_request.head.repo.full_name}}
+    - uses: actions/cache@v1
+      with:
+        path: ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
+    - name: Install Go dependencies
+      run: |
+        sudo gem install bosh-template
+        go install github.com/onsi/ginkgo/ginkgo
+    - name: Install shared tools
+      run: |
+        bin/tools
+        git config user.email "no-reply@quarks.cloudfoundry.org"
+        git config user.name "$GITHUB_ACTOR"
+    - name: Create k8s Kind Cluster
+      uses: engineerd/setup-kind@v0.3.0
+      with:
+       config: .github/kind-config.yaml
+       version: v0.7.0
+       image: kindest/node:${{matrix.kubernetes_version}}
+
+    - name: Run cluster tests
+      run: |
+        bin/test-integration
+        INTEGRATION_SUITE=storage bin/test-integration
+        INTEGRATION_SUITE=util bin/test-integration
+      env:
+        NODES: "3"
+        DEBUG: "no"
+        OPERATOR_TEST_STORAGE_CLASS: "standard"
+        PROJECT: "quarks-operator"
+        CF_OPERATOR_WEBHOOK_SERVICE_HOST: 172.17.0.1
+    - uses: actions/upload-artifact@v2
+      if: failure()
+      with:
+        name: ginkgo debug logs
+        path: "**/ginkgo-node-*.log"


### PR DESCRIPTION
This is more complicated than I thought:

* https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows#pull_request_target
* https://github.community/t/running-code-from-forks-with-pull-request-target/126688/4

`pull-request-target` makes sure the workflow definition is from the repo,
but secrets might still be exposed to code from the fork.

While the previous workflow looks safe in that regard, it would trigger tests
twice if any label was on a local, approved PR.

The duplicated workflow makes sure to checkout the forked code.

[#175030373](https://www.pivotaltracker.com/story/show/175030373)
