### PR TITLE
Only the first node applies CRDs

### DIFF
--- a/integration/environment/environment.go
+++ b/integration/environment/environment.go
@@ -17,10 +17,13 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc" //from https://github.com/kubernetes/client-go/issues/345
 	"k8s.io/client-go/rest"
 
+	qjob "code.cloudfoundry.org/quarks-job/pkg/kube/operator"
 	"code.cloudfoundry.org/quarks-operator/pkg/kube/client/clientset/versioned"
 	"code.cloudfoundry.org/quarks-operator/pkg/kube/operator"
 	"code.cloudfoundry.org/quarks-operator/testing"
+	qsec "code.cloudfoundry.org/quarks-secret/pkg/kube/operator"
 	qstsclient "code.cloudfoundry.org/quarks-statefulset/pkg/kube/client/clientset/versioned"
+	qsts "code.cloudfoundry.org/quarks-statefulset/pkg/kube/operator"
 	"code.cloudfoundry.org/quarks-utils/pkg/config"
 	utils "code.cloudfoundry.org/quarks-utils/testing/integration"
 	"code.cloudfoundry.org/quarks-utils/testing/machine"
@@ -149,5 +152,13 @@ func ApplyCRDs(kubeConfig *rest.Config) error {
 	if err != nil {
 		return err
 	}
-	return nil
+	err = qjob.ApplyCRDs(context.Background(), kubeConfig)
+	if err != nil {
+		return err
+	}
+	err = qsec.ApplyCRDs(context.Background(), kubeConfig)
+	if err != nil {
+		return err
+	}
+	return qsts.ApplyCRDs(context.Background(), kubeConfig)
 }

--- a/integration/environment/quarks_job_cmd.go
+++ b/integration/environment/quarks_job_cmd.go
@@ -33,6 +33,7 @@ func (q *QuarksJobCmd) Start(id string) error {
 		"-o", "ghcr.io/cloudfoundry-incubator",
 		"-r", "quarks-job",
 		"-t", quarksJobTag(),
+		"--apply-crd=false",
 		"--meltdown-duration", strconv.Itoa(defaultTestMeltdownDuration),
 		"--meltdown-requeue-after", strconv.Itoa(defaultTestMeltdownRequeueAfter),
 		"--monitored-id", id,

--- a/integration/environment/quarks_secret_cmd.go
+++ b/integration/environment/quarks_secret_cmd.go
@@ -23,6 +23,7 @@ func (q *QuarksSecretCmd) Build() error {
 // Start starts the specified quarks-secret in a namespace
 func (q *QuarksSecretCmd) Start(id string) error {
 	cmd := exec.Command(q.Path,
+		"--apply-crd=false",
 		"--meltdown-duration", strconv.Itoa(defaultTestMeltdownDuration),
 		"--meltdown-requeue-after", strconv.Itoa(defaultTestMeltdownRequeueAfter),
 		"--monitored-id", id,

--- a/integration/environment/quarks_statefulset_cmd.go
+++ b/integration/environment/quarks_statefulset_cmd.go
@@ -31,6 +31,7 @@ func (q *QuarksStatefulsetCmd) Start(id string, ns string, port int32) error {
 		"--operator-webhook-service-host", webhookHost(),
 		"--operator-webhook-service-port", strconv.Itoa(int(port)),
 		"--quarks-statefulset-namespace", ns,
+		"--apply-crd=false",
 		"--meltdown-duration", strconv.Itoa(defaultTestMeltdownDuration),
 		"--meltdown-requeue-after", strconv.Itoa(defaultTestMeltdownRequeueAfter),
 		"--monitored-id", id,


### PR DESCRIPTION
This might explain why tests were flaky at the beginning of the run.


```
2020-10-29T17:58:02.079+0100	INFO	cmd/apply_crd.go:19	Applying CRDs...
2020/10/29 17:58:02 quarks-secret command failed. Couldn't apply CRDs.: failed to apply CRD 'quarkssecrets.quarks.cloudfoundry.org': updating CRD 'quarkssecrets.quarks.cloudfoundry.org': Operation cannot be fulfilled on customresourcedefinitions.apiextensions.k8s.io "quarkssecrets.quarks.cloudfoundry.org": the object has been modified; please apply your changes to the latest version and try again
```

[#170670931](https://www.pivotaltracker.com/story/show/170670931)