### PR TITLE
Add TerminationGracePeriodSeconds to BOSH AgentSettings

### DIFF
--- a/docs/examples/bosh-deployment/quarks-gora-termination.yaml
+++ b/docs/examples/bosh-deployment/quarks-gora-termination.yaml
@@ -1,14 +1,3 @@
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: ops-scale
-data:
-  ops: |
-    - type: replace
-      path: /instance_groups/name=quarks-gora?/instances
-      value: 2
----
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -19,7 +8,7 @@ data:
     name: quarks-gora-deployment
     releases:
     - name: quarks-gora
-      version: "0.0.15"
+      version: "0.0.16"
       url: ghcr.io/cloudfoundry-incubator
       stemcell:
         os: SLE_15_SP1
@@ -31,8 +20,10 @@ data:
         bosh:
           agent:
             settings: 
-              terminationGracePeriodSeconds: 900
+              terminationGracePeriodSeconds: 70
       jobs:
+      - name: loop-drain-job
+        release: quarks-gora
       - name: quarks-gora
         release: quarks-gora
         properties:
@@ -52,7 +43,4 @@ metadata:
 spec:
   manifest:
     name: quarks-gora-manifest
-    type: configmap
-  ops:
-  - name: ops-scale
     type: configmap

--- a/docs/examples/bosh-deployment/quarks-gora-termination.yaml
+++ b/docs/examples/bosh-deployment/quarks-gora-termination.yaml
@@ -1,0 +1,58 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ops-scale
+data:
+  ops: |
+    - type: replace
+      path: /instance_groups/name=quarks-gora?/instances
+      value: 2
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: quarks-gora-manifest
+data:
+  manifest: |
+    ---
+    name: quarks-gora-deployment
+    releases:
+    - name: quarks-gora
+      version: "0.0.15"
+      url: ghcr.io/cloudfoundry-incubator
+      stemcell:
+        os: SLE_15_SP1
+        version: 27.10-7.0.0_374.gb8e8e6af
+    instance_groups:
+    - name: quarks-gora
+      instances: 1
+      env:
+        bosh:
+          agent:
+            settings: 
+              terminationGracePeriodSeconds: 900
+      jobs:
+      - name: quarks-gora
+        release: quarks-gora
+        properties:
+          quarks-gora:
+            port: 55556
+            ssl: false
+          quarks:
+            ports:
+            - name: "quarks-gora"
+              protocol: "TCP"
+              internal: 55556
+---
+apiVersion: quarks.cloudfoundry.org/v1alpha1
+kind: BOSHDeployment
+metadata:
+  name: quarks-gora-deployment
+spec:
+  manifest:
+    name: quarks-gora-manifest
+    type: configmap
+  ops:
+  - name: ops-scale
+    type: configmap

--- a/e2e/kube/examples_count_test.go
+++ b/e2e/kube/examples_count_test.go
@@ -19,6 +19,6 @@ var _ = Describe("Examples Directory Files", func() {
 		})
 		Expect(err).NotTo(HaveOccurred())
 		// If this testcase fails that means a test case is missing for an example in the docs folder
-		Expect(countFile).To(Equal(33))
+		Expect(countFile).To(Equal(34))
 	})
 })

--- a/e2e/kube/terminationgraceperiod_test.go
+++ b/e2e/kube/terminationgraceperiod_test.go
@@ -2,6 +2,8 @@ package kube_test
 
 import (
 	"path"
+	"strconv"
+	"time"
 
 	cmdHelper "code.cloudfoundry.org/quarks-utils/testing"
 
@@ -9,8 +11,10 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("BOSHDeployment", func() {
-	When("specifying terminationGracePeriodSeconds in bosh.env", func() {
+const graceTime = 70 // this has to match with quarks-gora-termination.yaml
+
+var _ = Describe("Instance group", func() {
+	When("specifying terminationGracePeriodSeconds in env.bosh.agent.settings", func() {
 		BeforeEach(func() {
 			By("Creating bdpl")
 			f := path.Join(examplesDir, "bosh-deployment/quarks-gora-termination.yaml")
@@ -20,16 +24,59 @@ var _ = Describe("BOSHDeployment", func() {
 			By("Checking for pods")
 			err = kubectl.Wait(namespace, "ready", "pod/quarks-gora-0", kubectl.PollTimeout)
 			Expect(err).ToNot(HaveOccurred())
-			err = kubectl.Wait(namespace, "ready", "pod/quarks-gora-1", kubectl.PollTimeout)
-			Expect(err).ToNot(HaveOccurred())
 		})
 
-		It("should create containers with the requested resources/limits", func() {
-			for _, pod := range []string{"quarks-gora-0", "quarks-gora-1"} {
-				requestedGrace, err := cmdHelper.GetData(namespace, "pods", pod, "jsonpath={.spec.terminationGracePeriodSeconds}")
+		It("should delay drain script termination meanwhile the instancegroup is running", func() {
+			pod := "quarks-gora-0"
+
+			uid, err := cmdHelper.GetData(namespace, "pods", pod, "jsonpath={.metadata.uid}")
+			Expect(err).ToNot(HaveOccurred())
+
+			// Make sure we set up sane defaults in the example and we don't change that accidentally.
+			// graceTime has to be > 30, plus additional 10 to avoid test flakyness.
+			// This test scenario is whenever we exceed Kubernetes default termination grace period which is 30s.
+			Expect(graceTime > 40).To(BeTrue())
+
+			requestedGrace, err := cmdHelper.GetData(namespace, "pods", pod, "jsonpath={.spec.terminationGracePeriodSeconds}")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(string(requestedGrace)).To(Equal(strconv.Itoa(graceTime)))
+
+			go func() {
+				_ = kubectl.Delete("pod", pod, "-n", namespace)
+			}()
+
+			isContainerUp := func() bool {
+				status, err := cmdHelper.GetData(namespace, "pods", pod, "jsonpath={.status.containerStatuses[?(@.name==\"quarks-gora-quarks-gora\")].state.running.startedAt}")
 				Expect(err).ToNot(HaveOccurred())
-				Expect(string(requestedGrace)).To(Equal("900"))
+				return len(status) != 0
 			}
+
+			differentUID := func() bool {
+				uidCurrent, err := cmdHelper.GetData(namespace, "pods", pod, "jsonpath={.metadata.uid}")
+				Expect(err).ToNot(HaveOccurred())
+				return (string(uid) == string(uidCurrent))
+			}
+
+			isUp := func() bool {
+				e, _ := kubectl.Exists(namespace, "pod", pod)
+				if !e {
+					return false
+				}
+
+				return differentUID() && isContainerUp()
+			}
+
+			// Make sure the gora container is up and running and it exceeds default 30s from Kubernetes.
+			// As we have setted up graceTime as terminationGrace and we expect the drain job to not terminate, the quarks-gora
+			// container should be up meanwhile the drain is running. We leave 10 extra seconds to avoid test flakyness
+			Consistently(isUp, time.Duration(time.Duration(graceTime-10)*time.Second), time.Duration(1*time.Second)).Should(BeTrue())
+
+			// Eventually, we should have a new pod as we exhaust the terminationGrace. Uses graceTime^2 as time window (not using pow for opt.)
+			Eventually(differentUID, time.Duration(time.Duration(graceTime*graceTime)*time.Second), time.Duration(1*time.Second)).Should(BeFalse())
+
+			err = kubectl.Wait(namespace, "ready", "pod/quarks-gora-0", kubectl.PollTimeout)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(isContainerUp()).To(BeTrue())
 		})
 	})
 })

--- a/e2e/kube/terminationgraceperiod_test.go
+++ b/e2e/kube/terminationgraceperiod_test.go
@@ -1,0 +1,35 @@
+package kube_test
+
+import (
+	"path"
+
+	cmdHelper "code.cloudfoundry.org/quarks-utils/testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("BOSHDeployment", func() {
+	When("specifying terminationGracePeriodSeconds in bosh.env", func() {
+		BeforeEach(func() {
+			By("Creating bdpl")
+			f := path.Join(examplesDir, "bosh-deployment/quarks-gora-termination.yaml")
+			err := cmdHelper.Create(namespace, f)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Checking for pods")
+			err = kubectl.Wait(namespace, "ready", "pod/quarks-gora-0", kubectl.PollTimeout)
+			Expect(err).ToNot(HaveOccurred())
+			err = kubectl.Wait(namespace, "ready", "pod/quarks-gora-1", kubectl.PollTimeout)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should create containers with the requested resources/limits", func() {
+			for _, pod := range []string{"quarks-gora-0", "quarks-gora-1"} {
+				requestedGrace, err := cmdHelper.GetData(namespace, "pods", pod, "jsonpath={.spec.terminationGracePeriodSeconds}")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(string(requestedGrace)).To(Equal("900"))
+			}
+		})
+	})
+})

--- a/pkg/bosh/bpmconverter/resources.go
+++ b/pkg/bosh/bpmconverter/resources.go
@@ -208,10 +208,11 @@ func (kc *BPMConverter) serviceToQuarksStatefulSet(
 							Annotations: instanceGroup.Env.AgentEnvBoshConfig.Agent.Settings.Annotations,
 						},
 						Spec: corev1.PodSpec{
-							Affinity:       instanceGroup.Env.AgentEnvBoshConfig.Agent.Settings.Affinity,
-							Volumes:        volumes,
-							InitContainers: initContainers,
-							Containers:     containers,
+							TerminationGracePeriodSeconds: instanceGroup.Env.AgentEnvBoshConfig.Agent.Settings.TerminationGracePeriodSeconds,
+							Affinity:                      instanceGroup.Env.AgentEnvBoshConfig.Agent.Settings.Affinity,
+							Volumes:                       volumes,
+							InitContainers:                initContainers,
+							Containers:                    containers,
 							SecurityContext: &corev1.PodSecurityContext{
 								FSGroup: &admGroupID,
 							},

--- a/pkg/bosh/bpmconverter/resources_test.go
+++ b/pkg/bosh/bpmconverter/resources_test.go
@@ -186,7 +186,7 @@ var _ = Describe("BPM Converter", func() {
 				})
 
 				It("converts the instance group to an QuarksStatefulSet", func() {
-
+					t := int64(1000)
 					tolerations := []corev1.Toleration{
 						{
 							Key:      "key",
@@ -196,6 +196,7 @@ var _ = Describe("BPM Converter", func() {
 						},
 					}
 					m.InstanceGroups[1].Env.AgentEnvBoshConfig.Agent.Settings.Tolerations = tolerations
+					m.InstanceGroups[1].Env.AgentEnvBoshConfig.Agent.Settings.TerminationGracePeriodSeconds = &t
 
 					activePassiveProbes := map[string]corev1.Probe{
 						"rep-server": corev1.Probe{
@@ -233,6 +234,7 @@ var _ = Describe("BPM Converter", func() {
 						qstsv1a1.LabelPodOrdinal:    "0",
 						qstsv1a1.LabelActivePod:     "active",
 					}))
+					Expect(stS.Spec.TerminationGracePeriodSeconds).To(Equal(&t))
 				})
 
 				It("converts the instance group to an QuarksStatefulSet", func() {

--- a/pkg/bosh/manifest/instance_group.go
+++ b/pkg/bosh/manifest/instance_group.go
@@ -253,19 +253,20 @@ type PreRenderOps struct {
 // These annotations and labels are added to kube resources.
 // Affinity & tolerations are added into the pod's definition.
 type AgentSettings struct {
-	Annotations                  map[string]string             `json:"annotations,omitempty"`
-	Labels                       map[string]string             `json:"labels,omitempty"`
-	Affinity                     *corev1.Affinity              `json:"affinity,omitempty"`
-	DisableLogSidecar            bool                          `json:"disable_log_sidecar,omitempty" yaml:"disable_log_sidecar,omitempty"`
-	ServiceAccountName           string                        `json:"serviceAccountName,omitempty" yaml:"serviceAccountName,omitempty"`
-	AutomountServiceAccountToken *bool                         `json:"automountServiceAccountToken,omitempty" yaml:"automountServiceAccountToken,omitempty"`
-	ImagePullSecrets             []corev1.LocalObjectReference `json:"imagePullSecrets,omitempty"`
-	Tolerations                  []corev1.Toleration           `json:"tolerations,omitempty"`
-	EphemeralAsPVC               bool                          `json:"ephemeralAsPVC,omitempty"`
-	Disks                        Disks                         `json:"disks,omitempty"`
-	JobBackoffLimit              *int32                        `json:"jobBackoffLimit,omitempty"`
-	PreRenderOps                 *PreRenderOps                 `json:"preRenderOps,omitempty"`
-	InjectReplicasEnv            *bool                         `json:"injectReplicasEnv,omitempty"`
+	Annotations                   map[string]string             `json:"annotations,omitempty"`
+	Labels                        map[string]string             `json:"labels,omitempty"`
+	Affinity                      *corev1.Affinity              `json:"affinity,omitempty"`
+	DisableLogSidecar             bool                          `json:"disable_log_sidecar,omitempty" yaml:"disable_log_sidecar,omitempty"`
+	ServiceAccountName            string                        `json:"serviceAccountName,omitempty" yaml:"serviceAccountName,omitempty"`
+	AutomountServiceAccountToken  *bool                         `json:"automountServiceAccountToken,omitempty" yaml:"automountServiceAccountToken,omitempty"`
+	ImagePullSecrets              []corev1.LocalObjectReference `json:"imagePullSecrets,omitempty"`
+	Tolerations                   []corev1.Toleration           `json:"tolerations,omitempty"`
+	EphemeralAsPVC                bool                          `json:"ephemeralAsPVC,omitempty"`
+	Disks                         Disks                         `json:"disks,omitempty"`
+	JobBackoffLimit               *int32                        `json:"jobBackoffLimit,omitempty"`
+	PreRenderOps                  *PreRenderOps                 `json:"preRenderOps,omitempty"`
+	InjectReplicasEnv             *bool                         `json:"injectReplicasEnv,omitempty"`
+	TerminationGracePeriodSeconds *int64                        `json:"terminationGracePeriodSeconds,omitempty" yaml:"terminationGracePeriodSeconds,omitempty"`
 }
 
 // Set overrides labels and annotations with operator-owned metadata.


### PR DESCRIPTION
## Motivation and Context

[#175084409](https://www.pivotaltracker.com/story/show/175084409)
Instead of creating a reconciler, just allow instance groups to specify a `terminationGracePeriodSeconds`.

In this way each instance group can set the `terminationGracePeriodSeconds` for  the Pod, which defaults might be too short for pre-drain scripts to be executed in time ( see https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-termination ).

## Checklist:

Check item if necessary.

- [ ] Review PRs of changed Quarks dependencies
- [ ] Update this PR after the release of Quarks dependencies
