### PR TITLE
Fix log message issues with webhooks

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -179,7 +179,7 @@ jobs:
         INTEGRATION_SUITE=util bin/test-integration
       env:
         NODES: "3"
-        DEBUG: "no"
+        DEBUG: "yes"
         OPERATOR_TEST_STORAGE_CLASS: "standard"
         PROJECT: "quarks-operator"
         CF_OPERATOR_WEBHOOK_SERVICE_HOST: 172.17.0.1

--- a/pkg/kube/controllers/quarkslink/pod_mutator.go
+++ b/pkg/kube/controllers/quarkslink/pod_mutator.go
@@ -34,11 +34,8 @@ var _ admission.Handler = &PodMutator{}
 
 // NewPodMutator returns a new mutator to mount secrets on entangled pods
 func NewPodMutator(log *zap.SugaredLogger, config *config.Config) admission.Handler {
-	mutatorLog := log.Named("quarks-link-pod-mutator")
-	mutatorLog.Info("Creating a Pod mutator for QuarksLink")
-
 	return &PodMutator{
-		log:    mutatorLog,
+		log:    log,
 		config: config,
 	}
 }
@@ -54,7 +51,7 @@ func (m *PodMutator) Handle(ctx context.Context, req admission.Request) admissio
 
 	updatedPod := pod.DeepCopy()
 	if validEntanglement(pod.GetAnnotations()) {
-		m.log.Debugf("Mutating pod '%s/%s', adding restart-on-update annotation and entanglement secrets", pod.Namespace, pod.Name)
+		m.log.Debugf("Mutating pod '%s/%s', adding restart-on-update annotation and entanglement secrets", req.Namespace, pod.Name)
 
 		// Apply quarksrestart annotation so the link gets restarted when mounted secrets are changed
 		annotations := updatedPod.Annotations

--- a/pkg/kube/controllers/quarkslink/pod_webhook.go
+++ b/pkg/kube/controllers/quarkslink/pod_webhook.go
@@ -16,7 +16,7 @@ import (
 
 // NewBOSHLinkPodMutator returns a new webhook to mount BOSH link secrets on entangled pods
 func NewBOSHLinkPodMutator(log *zap.SugaredLogger, config *config.Config) *wh.OperatorWebhook {
-	log = logger.Unskip(log, "boshlink-mutator")
+	log = logger.Unskip(log, "bosh-link-mutator")
 	log.Info("Setting up mutator for mounting BOSH links in entangled pods")
 
 	mutator := NewPodMutator(log, config)


### PR DESCRIPTION
* set up logging only once, in webhook
* mutator might get an empty pod.Namespace


[#175194501](https://www.pivotaltracker.com/story/show/175194501)