### PR TITLE
Consume coredns from ghcr instead of dockerhub in Helm chart

### DIFF
--- a/deploy/helm/quarks/values.yaml
+++ b/deploy/helm/quarks/values.yaml
@@ -42,7 +42,7 @@ operator:
     # port the webhook server listens on
     port: "2999"
   # boshDNSDockerImage is the docker image used for emulating bosh DNS (a CoreDNS image).
-  boshDNSDockerImage: "cfcontainerization/coredns:0.1.0-1.6.7-bp152.1.19"
+  boshDNSDockerImage: "ghcr.io/cfcontainerizationbot/coredns:0.1.0-1.6.7-bp152.1.19"
   hookDockerImage: "ghcr.io/cfcontainerizationbot/kubecf-kubectl:v1.19.2"
 
 # serviceAccount contains the configuration


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- Describe your changes in detail -->

In the Helm chart, consume SUSE's `ghcr.io/cfcontainerizationbot/coredns` image instead of `cfcontainerization/coredns`.

## Motivation and Context

This reduces Dockerhub rate limiting hits.
Image is being pushed to ghcr by https://concourse.suse.de/teams/main/pipelines/obs-to-ghcr-pusher.

Needed by https://github.com/cloudfoundry-incubator/kubecf/issues/1557.

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue or belongs to a story, please add a link here. -->

## Checklist:

Check item if necessary.

- [ ] Review PRs of changed Quarks dependencies
- [ ] Update this PR after the release of Quarks dependencies
