### PR TITLE
Don't use upstream, use fallthrough in BOSH DNS

### DIFF
--- a/e2e/kube/examples_test.go
+++ b/e2e/kube/examples_test.go
@@ -285,7 +285,7 @@ var _ = Describe("Examples Directory", func() {
 				"foo.nats.service.cf.internal",
 			}
 			for _, name := range unresolvableWildCardNames {
-				err = kubectl.RunCommandWithCheckString(namespace, podName, fmt.Sprintf("nslookup %s || true", name), "no servers could be reached")
+				err = kubectl.RunCommandWithCheckString(namespace, podName, fmt.Sprintf("nslookup %s || true", name), "NXDOMAIN")
 				Expect(err).NotTo(HaveOccurred())
 			}
 

--- a/pkg/kube/util/boshdns/bosh_test.go
+++ b/pkg/kube/util/boshdns/bosh_test.go
@@ -229,17 +229,17 @@ var _ = Describe("BOSHDomainNameService", func() {
 	template IN A bits.service.cf.internal {
 		match ^bits\.service\.cf\.internal\.$
 		answer "{{ .Name }} 60 IN CNAME bits.default.svc."
-		upstream`))
+		fallthrough`))
 				Expect(corefile).To(ContainSubstring(`
 	template IN AAAA bits.service.cf.internal {
 		match ^bits\.service\.cf\.internal\.$
 		answer "{{ .Name }} 60 IN CNAME bits.default.svc."
-		upstream`))
+		fallthrough`))
 				Expect(corefile).To(ContainSubstring(`
 	template IN CNAME bbs1.service.cf.internal {
 		match ^bbs1\.service\.cf\.internal\.$
 		answer "{{ .Name }} 60 IN CNAME diego-api.default.svc."
-		upstream
+		fallthrough
 	}`))
 
 				By("checking for entries which are missing an instance group, but do not use _ query")
@@ -247,14 +247,14 @@ var _ = Describe("BOSHDomainNameService", func() {
 	template IN A uaa.service.cf.internal {
 		match ^uaa\.service\.cf\.internal\.$
 		answer "{{ .Name }} 60 IN CNAME uaa.default.svc."
-		upstream`))
+		fallthrough`))
 
 				By("checking for entries for diego-cells in mutli-zone")
 				Expect(corefile).To(ContainSubstring(`
 	template IN A diego-cell-z0-0.cell.service.cf.internal {
 		match ^diego-cell-z0-0\.cell\.service\.cf\.internal\.$
 		answer "{{ .Name }} 60 IN CNAME diego-cell-z0-0.default.svc."
-		upstream`))
+		fallthrough`))
 			})
 		})
 
@@ -309,7 +309,7 @@ var _ = Describe("BOSHDomainNameService", func() {
 	template IN CNAME bbs1.service.cf.internal {
 		match ^bbs1\.service\.cf\.internal\.$
 		answer "{{ .Name }} 60 IN CNAME diego-api.default.svc."
-		upstream
+		fallthrough
 	}`))
 			})
 		})

--- a/pkg/kube/util/boshdns/corefile.go
+++ b/pkg/kube/util/boshdns/corefile.go
@@ -209,15 +209,15 @@ const cnameTemplate = `
 	template IN A %[4]s {
 		match ^%[2]s%[1]s\.$
 		answer "{{ .Name }} 60 IN CNAME %[3]s"
-		upstream
+		fallthrough
 	}
 	template IN AAAA %[4]s {
 		match ^%[2]s%[1]s\.$
 		answer "{{ .Name }} 60 IN CNAME %[3]s"
-		upstream
+		fallthrough
 	}
 	template IN CNAME %[4]s {
 		match ^%[2]s%[1]s\.$
 		answer "{{ .Name }} 60 IN CNAME %[3]s"
-		upstream
+		fallthrough
 	}`

--- a/pkg/kube/util/boshdns/corefile_test.go
+++ b/pkg/kube/util/boshdns/corefile_test.go
@@ -101,7 +101,7 @@ var _ = Describe("Corefile", func() {
 	template IN A bits.service.cf.internal {
 		match ^bits\.service\.cf\.internal\.$
 		answer "{{ .Name }} 60 IN CNAME bits.default.svc."
-		upstream`))
+		fallthrough`))
 			})
 		})
 


### PR DESCRIPTION
The upstream keyword causes the server to query forwarders if a match is made prematurely, instead of trying the rest of the configuration.

fixes #1234 

[#175676313](https://www.pivotaltracker.com/story/show/175676313)
