### PR TITLE
Use the helper template to generate a chart name that is a valid label

### DIFF
--- a/deploy/helm/quarks/templates/hooks.yaml
+++ b/deploy/helm/quarks/templates/hooks.yaml
@@ -114,7 +114,7 @@ spec:
       labels:
         app.kubernetes.io/managed-by: {{ $.Release.Service | quote }}
         app.kubernetes.io/instance: {{ $.Release.Name | quote }}
-        helm.sh/chart: "{{ $.Chart.Name }}-{{ $.Chart.Version }}"
+        helm.sh/chart: {{ include "cf-operator.chart" . }}
     spec:
       restartPolicy: Never
       serviceAccountName: {{$hook}}-helm-hook


### PR DESCRIPTION
With the current chart you get the following error on upgrades:

```
Error: UPGRADE FAILED: pre-upgrade hooks failed: warning: Hook pre-upgrade quarks/templates/hooks.yaml failed: Job.batch "cf-operator-pre-upgrade-hook" is invalid: spec.template.labels: Invalid value: "quarks-7.0.1+0.g5396b11": a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyValue',  or 'my_value',  or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?')
```

The PR is untested, but follows the pattern we use everywhere else.