### PR TITLE
Add ratelimiter to boshdeployment controllers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ require (
 	code.cloudfoundry.org/quarks-job v1.0.213
 	code.cloudfoundry.org/quarks-secret v1.0.754
 	code.cloudfoundry.org/quarks-statefulset v0.0.1308-g6a8b2220
-	code.cloudfoundry.org/quarks-utils v0.0.2-0.20201104164019-cb2fb89e3552
+	code.cloudfoundry.org/quarks-utils v0.0.2-0.20201209094741-f00172bc21a7
 	github.com/SUSE/go-patch v0.3.0
 	github.com/bmatcuk/doublestar v1.1.1 // indirect
 	github.com/charlievieth/fs v0.0.0-20170613215519-7dc373669fa1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -18,9 +18,6 @@ code.cloudfoundry.org/quarks-secret v1.0.754 h1:pQYbci/oWA7PGTaNa6iBAQdvhHwBj/O9
 code.cloudfoundry.org/quarks-secret v1.0.754/go.mod h1:5XWVFJ4wVZCbElNBl4Sjb38r038WsxrrSt0DMIqhSQU=
 code.cloudfoundry.org/quarks-statefulset v0.0.1308-g6a8b2220 h1:XHIF8hMG8SOaK4lm2NijY8RPwUVzwD9W1ohcijm2ycw=
 code.cloudfoundry.org/quarks-statefulset v0.0.1308-g6a8b2220/go.mod h1:98ljusevv5l/Cww0+Sm1uUhxRSW9NbsSRWwwqoXbCNA=
-code.cloudfoundry.org/quarks-utils v0.0.2-0.20201027114038-8aab73d224e4/go.mod h1:K8KH67rdNk9+VPOA5QRgrujTFhbmtqxLOuPQ6APL6ks=
-code.cloudfoundry.org/quarks-utils v0.0.2-0.20201104164019-cb2fb89e3552 h1:5wX9bbxBi7ViUucYcnZTNnbwV/BZ9EDhsRXg/UtrleY=
-code.cloudfoundry.org/quarks-utils v0.0.2-0.20201104164019-cb2fb89e3552/go.mod h1:K8KH67rdNk9+VPOA5QRgrujTFhbmtqxLOuPQ6APL6ks=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/Azure/azure-sdk-for-go v16.2.1+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
 github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78/go.mod h1:LmzpDX56iTiv29bbRTIsUNlaFfuhWRQBWjQdVyAevI8=

--- a/pkg/kube/controllers/boshdeployment/bpm_controller.go
+++ b/pkg/kube/controllers/boshdeployment/bpm_controller.go
@@ -23,6 +23,7 @@ import (
 	"code.cloudfoundry.org/quarks-utils/pkg/meltdown"
 	"code.cloudfoundry.org/quarks-utils/pkg/monitorednamespace"
 	"code.cloudfoundry.org/quarks-utils/pkg/names"
+	"code.cloudfoundry.org/quarks-utils/pkg/ratelimiter"
 	vss "code.cloudfoundry.org/quarks-utils/pkg/versionedsecretstore"
 )
 
@@ -43,6 +44,7 @@ func AddBPM(ctx context.Context, config *config.Config, mgr manager.Manager) err
 	c, err := controller.New("bpm-controller", mgr, controller.Options{
 		Reconciler:              r,
 		MaxConcurrentReconciles: config.MaxBoshDeploymentWorkers,
+		RateLimiter:             ratelimiter.New(),
 	})
 	if err != nil {
 		return errors.Wrap(err, "Adding BPM controller to manager failed.")

--- a/pkg/kube/controllers/boshdeployment/deployment_controller.go
+++ b/pkg/kube/controllers/boshdeployment/deployment_controller.go
@@ -27,6 +27,7 @@ import (
 	"code.cloudfoundry.org/quarks-utils/pkg/config"
 	"code.cloudfoundry.org/quarks-utils/pkg/ctxlog"
 	"code.cloudfoundry.org/quarks-utils/pkg/monitorednamespace"
+	"code.cloudfoundry.org/quarks-utils/pkg/ratelimiter"
 	"code.cloudfoundry.org/quarks-utils/pkg/skip"
 )
 
@@ -50,6 +51,7 @@ func AddDeployment(ctx context.Context, config *config.Config, mgr manager.Manag
 	c, err := controller.New("boshdeployment-controller", mgr, controller.Options{
 		Reconciler:              r,
 		MaxConcurrentReconciles: config.MaxBoshDeploymentWorkers,
+		RateLimiter:             ratelimiter.New(),
 	})
 	if err != nil {
 		return errors.Wrap(err, "Adding Bosh deployment controller to manager failed.")

--- a/pkg/kube/controllers/boshdeployment/withops_controller.go
+++ b/pkg/kube/controllers/boshdeployment/withops_controller.go
@@ -27,6 +27,7 @@ import (
 	"code.cloudfoundry.org/quarks-utils/pkg/ctxlog"
 	"code.cloudfoundry.org/quarks-utils/pkg/monitorednamespace"
 	"code.cloudfoundry.org/quarks-utils/pkg/names"
+	"code.cloudfoundry.org/quarks-utils/pkg/ratelimiter"
 	"code.cloudfoundry.org/quarks-utils/pkg/skip"
 )
 
@@ -49,6 +50,7 @@ func AddWithOps(ctx context.Context, config *config.Config, mgr manager.Manager)
 	c, err := controller.New("withops-controller", mgr, controller.Options{
 		Reconciler:              r,
 		MaxConcurrentReconciles: config.MaxBoshDeploymentWorkers,
+		RateLimiter:             ratelimiter.New(),
 	})
 	if err != nil {
 		return errors.Wrap(err, "Adding withops controller to manager failed.")


### PR DESCRIPTION
Increase per-item rate limit from 5ms to 5s.

[#174439982](https://www.pivotaltracker.com/story/show/174439982)
