### PR TITLE
Use startup ordinal to select ig service

### DIFF
--- a/pkg/bosh/bpmconverter/env_keys.go
+++ b/pkg/bosh/bpmconverter/env_keys.go
@@ -12,7 +12,7 @@ const (
 	PodIPEnvVar = "POD_IP"
 	// EnvInitialRollout is set to "false" if this is not the first time the instance group has run
 	EnvInitialRollout = "INITIAL_ROLLOUT"
-	// EnvPodOrdinal is the environment variable which holds the pods startup index, quarks-job also sets this to 0
+	// EnvPodOrdinal is the environment variable which holds the pods startup index
 	EnvPodOrdinal = "POD_ORDINAL"
 
 	// EnvReplicas is set to 1

--- a/pkg/bosh/bpmconverter/resources.go
+++ b/pkg/bosh/bpmconverter/resources.go
@@ -447,10 +447,10 @@ func (kc *BPMConverter) generateServices(
 			azIndex = 0
 		}
 		labels := map[string]string{
-			bdv1.LabelDeploymentName:    deploymentName,
-			bdv1.LabelInstanceGroupName: instanceGroup.Name,
-			qstsv1a1.LabelAZIndex:       strconv.Itoa(azIndex),
-			qstsv1a1.LabelPodOrdinal:    strconv.Itoa(ordinal),
+			bdv1.LabelDeploymentName:     deploymentName,
+			bdv1.LabelInstanceGroupName:  instanceGroup.Name,
+			qstsv1a1.LabelAZIndex:        strconv.Itoa(azIndex),
+			qstsv1a1.LabelStartupOrdinal: strconv.Itoa(ordinal),
 		}
 		if includeActiveSelector {
 			labels[qstsv1a1.LabelActivePod] = "active"


### PR DESCRIPTION
This would make nats-1 with startup ordinal 0 (which happens after an
upgrade) use the nats-0 service. That service selects the nats-1 pod.

It is consistent with the template rendering job instances address in https://github.com/cloudfoundry-incubator/quarks-operator/blob/master/pkg/bosh/manifest/instance_group.go#L150
