### PR TITLE
Remove dirty flag from version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -289,7 +289,6 @@ jobs:
         DOCKER_IMAGE_REPOSITORY: "${{ env.DOCKER_RELEASE_REPOSITORY }}"
         ARTIFACT_VERSION: "${{ steps.get_version.outputs.artifact_version }}"
         DOCKER_IMAGE_TAG: "${{ steps.get_version.outputs.artifact_version }}"
-        RELEASE: "true"
       id: build_helm
 
     - uses: actions/setup-python@v2

--- a/bin/build-helm
+++ b/bin/build-helm
@@ -13,14 +13,7 @@ output_dir="$GIT_ROOT/helm"
 # helm does not accept a leading 'v'
 version=$(echo "$ARTIFACT_VERSION" | sed 's/^v//')
 # helm considers any version with a dash to be a pre-release
-if [ ${RELEASE+x} ]; then
-  # if version contains '-dirty', it's a bug in CI
-  if echo "$version" | grep -q 'dirty'; then
-    echo "release versions may not contain '-dirty': $version"
-    exit 1
-  fi
-  version=$(echo "$version" | sed 's/-/+/')
-fi
+version=$(echo "$version" | sed 's/-/+/')
 
 [ -d "$output_dir" ] && rm -r "$output_dir"
 cp -r "$GIT_ROOT/deploy/helm" "$output_dir"

--- a/bin/include/versioning
+++ b/bin/include/versioning
@@ -4,13 +4,11 @@
 # describe" output.
 # The ARTIFACT_VERSION is also compatible with docker. It will not contain any
 # build metadata, since docker can't understand a '+'.
-# If run on a dirty working tree, '-dirty' is added to the pre-release part.
 
 GIT_DESCRIBE=$(git describe --tags --long || (git tag -a v0.0.0 -m "tag v0.0.0"; git describe --tags --long))
 
 GIT_COMMITS=$(echo "${GIT_DESCRIBE}" | awk -F - '{ print $2 }')
 GIT_SHA=$(echo "${GIT_DESCRIBE}" | awk -F - '{ print $3 }' )
 GIT_TAG=$(echo "${GIT_DESCRIBE}" | awk -F - '{ print $1 }')
-[ -z "$(git status --porcelain -uno | grep -v -E '^ M (integration|e2e|docs)')" ] || GIT_TAG="${GIT_TAG}-dirty"
 
 ARTIFACT_VERSION="${GIT_TAG}-${GIT_COMMITS}.${GIT_SHA}"


### PR DESCRIPTION
This would always be added, when building the binary in Docker. The COPY
command uses .dockerignore and git shows the ignored files as deleted.
