### PR TITLE
Errands no longer use container-run wrapper

### DIFF
--- a/integration/bdpl_update_test.go
+++ b/integration/bdpl_update_test.go
@@ -176,7 +176,7 @@ var _ = Describe("BDPL updates", func() {
 				Expect(err).NotTo(HaveOccurred(), "error retrieving clusterIP service")
 
 				tearDown, err := env.CreateService(env.Namespace, env.NodePortService("nats-service", "nats", svc.Spec.Ports[0].Port))
-				defer func(tdf machine.TearDownFunc) { Expect(tdf()).To(Succeed()) }(tearDown)
+				tearDowns = append(tearDowns, tearDown)
 				Expect(err).NotTo(HaveOccurred(), "error creating service")
 
 				service, err := env.GetService(env.Namespace, "nats-service")
@@ -554,11 +554,11 @@ var _ = Describe("BDPL updates", func() {
 			manifestName := "bosh-manifest-two-instance-groups"
 			tearDown, err := env.CreateConfigMap(env.Namespace, env.BOSHManifestConfigMap("fooconfigmap", bm.BOSHManifestWithTwoInstanceGroups))
 			Expect(err).NotTo(HaveOccurred())
-			defer func(tdf machine.TearDownFunc) { Expect(tdf()).To(Succeed()) }(tearDown)
+			tearDowns = append(tearDowns, tearDown)
 
 			_, tearDown, err = env.CreateBOSHDeployment(env.Namespace, env.DefaultBOSHDeployment(manifestName, "fooconfigmap"))
 			Expect(err).NotTo(HaveOccurred())
-			defer func(tdf machine.TearDownFunc) { Expect(tdf()).To(Succeed()) }(tearDown)
+			tearDowns = append(tearDowns, tearDown)
 
 			By("checking for nats instance group pods")
 			err = env.WaitForInstanceGroup(env.Namespace, manifestName, "nats", 2)

--- a/integration/drain_test.go
+++ b/integration/drain_test.go
@@ -12,9 +12,14 @@ import (
 var _ = Describe("Drain", func() {
 	var (
 		boshDeployment bdv1.BOSHDeployment
+		tearDowns      []machine.TearDownFunc
 	)
 	BeforeEach(func() {
 		boshDeployment = env.DefaultBOSHDeployment("test", "manifest")
+	})
+
+	AfterEach(func() {
+		Expect(env.TearDownAll(tearDowns)).To(Succeed())
 	})
 
 	When("deleting the deployment", func() {
@@ -22,11 +27,11 @@ var _ = Describe("Drain", func() {
 			cm := env.BOSHManifestConfigMap("manifest", bm.Drains)
 			tearDown, err := env.CreateConfigMap(env.Namespace, cm)
 			Expect(err).NotTo(HaveOccurred())
-			defer func(tdf machine.TearDownFunc) { Expect(tdf()).To(Succeed()) }(tearDown)
+			tearDowns = append(tearDowns, tearDown)
 
 			_, tearDown, err = env.CreateBOSHDeployment(env.Namespace, boshDeployment)
 			Expect(err).NotTo(HaveOccurred())
-			defer func(tdf machine.TearDownFunc) { Expect(tdf()).To(Succeed()) }(tearDown)
+			tearDowns = append(tearDowns, tearDown)
 
 			By("checking for instance group pods")
 			err = env.WaitForInstanceGroup(env.Namespace, "test", "drains", 1)

--- a/integration/util/tlogs_test.go
+++ b/integration/util/tlogs_test.go
@@ -13,6 +13,12 @@ import (
 )
 
 var _ = Describe("when testing tail-logs subcommand", func() {
+	var tearDowns []machine.TearDownFunc
+
+	AfterEach(func() {
+		Expect(env.TearDownAll(tearDowns)).To(Succeed())
+	})
+
 	Context("subcommand must be working", func() {
 		podName := "test-pod-bar-foo"
 		parentCName := "fake-nats"
@@ -29,7 +35,7 @@ var _ = Describe("when testing tail-logs subcommand", func() {
 
 			tearDown, err := env.CreatePod(env.Namespace, testPod)
 			Expect(err).NotTo(HaveOccurred())
-			defer func(tdf machine.TearDownFunc) { Expect(tdf()).To(Succeed()) }(tearDown)
+			tearDowns = append(tearDowns, tearDown)
 
 			err = env.WaitForPod(env.Namespace, podName)
 			Expect(err).NotTo(HaveOccurred())
@@ -55,7 +61,7 @@ var _ = Describe("when testing tail-logs subcommand", func() {
 
 			tearDown, err := env.CreatePod(env.Namespace, testPod)
 			Expect(err).NotTo(HaveOccurred())
-			defer func(tdf machine.TearDownFunc) { Expect(tdf()).To(Succeed()) }(tearDown)
+			tearDowns = append(tearDowns, tearDown)
 
 			err = env.WaitForPod(env.Namespace, podName)
 			Expect(err).NotTo(HaveOccurred())
@@ -80,7 +86,7 @@ var _ = Describe("when testing tail-logs subcommand", func() {
 
 			tearDown, err := env.CreatePod(env.Namespace, testPod)
 			Expect(err).NotTo(HaveOccurred())
-			defer func(tdf machine.TearDownFunc) { Expect(tdf()).To(Succeed()) }(tearDown)
+			tearDowns = append(tearDowns, tearDown)
 
 			err = env.WaitForPod(env.Namespace, podName)
 			Expect(err).NotTo(HaveOccurred())
@@ -100,7 +106,7 @@ var _ = Describe("when testing tail-logs subcommand", func() {
 
 			tearDown, err := env.CreatePod(env.Namespace, testPod)
 			Expect(err).NotTo(HaveOccurred())
-			defer func(tdf machine.TearDownFunc) { Expect(tdf()).To(Succeed()) }(tearDown)
+			tearDowns = append(tearDowns, tearDown)
 
 			err = env.WaitForPod(env.Namespace, podName)
 			Expect(err).NotTo(HaveOccurred())
@@ -120,7 +126,7 @@ var _ = Describe("when testing tail-logs subcommand", func() {
 
 			tearDown, err := env.CreatePod(env.Namespace, testPod)
 			Expect(err).NotTo(HaveOccurred())
-			defer func(tdf machine.TearDownFunc) { Expect(tdf()).To(Succeed()) }(tearDown)
+			tearDowns = append(tearDowns, tearDown)
 
 			err = env.WaitForPod(env.Namespace, podName)
 			Expect(err).NotTo(HaveOccurred())
@@ -131,7 +137,6 @@ var _ = Describe("when testing tail-logs subcommand", func() {
 			time.Sleep(1 * time.Minute)
 			err = env.WaitForPodContainerLogMsg(env.Namespace, podName, sidecarCName, "running logrotate")
 			Expect(err).NotTo(HaveOccurred())
-
 		})
 	})
 })

--- a/pkg/bosh/bpmconverter/container_factory.go
+++ b/pkg/bosh/bpmconverter/container_factory.go
@@ -46,6 +46,7 @@ const (
 // ContainerFactoryImpl is a concrete implementation of ContainerFactor.
 type ContainerFactoryImpl struct {
 	instanceGroupName    string
+	errand               bool
 	version              string
 	disableLogSidecar    bool
 	releaseImageProvider bdm.ReleaseImageProvider
@@ -53,9 +54,10 @@ type ContainerFactoryImpl struct {
 }
 
 // NewContainerFactory returns a concrete implementation of ContainerFactory.
-func NewContainerFactory(instanceGroupName string, version string, disableLogSidecar bool, releaseImageProvider bdm.ReleaseImageProvider, bpmConfigs bpm.Configs) *ContainerFactoryImpl {
+func NewContainerFactory(igName string, errand bool, version string, disableLogSidecar bool, releaseImageProvider bdm.ReleaseImageProvider, bpmConfigs bpm.Configs) ContainerFactory {
 	return &ContainerFactoryImpl{
-		instanceGroupName:    instanceGroupName,
+		instanceGroupName:    igName,
+		errand:               errand,
 		version:              version,
 		disableLogSidecar:    disableLogSidecar,
 		releaseImageProvider: releaseImageProvider,

--- a/pkg/bosh/bpmconverter/container_factory_test.go
+++ b/pkg/bosh/bpmconverter/container_factory_test.go
@@ -20,7 +20,7 @@ import (
 
 var _ = Describe("ContainerFactory", func() {
 	var (
-		containerFactory     *ContainerFactoryImpl
+		containerFactory     ContainerFactory
 		bpmConfigs           bpm.Configs
 		releaseImageProvider *fakes.FakeReleaseImageProvider
 		jobs                 []bdm.Job
@@ -165,7 +165,7 @@ var _ = Describe("ContainerFactory", func() {
 	})
 
 	JustBeforeEach(func() {
-		containerFactory = NewContainerFactory("fake-ig", "v1", false, releaseImageProvider, bpmConfigs)
+		containerFactory = NewContainerFactory("fake-ig", false, "v1", false, releaseImageProvider, bpmConfigs)
 	})
 
 	Context("JobsToContainers", func() {
@@ -320,7 +320,7 @@ var _ = Describe("ContainerFactory", func() {
 					},
 				},
 			}
-			containerFactory = NewContainerFactory("fake-ig", "v1", false, releaseImageProvider, bpmConfigsWithError)
+			containerFactory = NewContainerFactory("fake-ig", false, "v1", false, releaseImageProvider, bpmConfigsWithError)
 			actWithError := func() ([]corev1.Container, error) {
 				return containerFactory.JobsToContainers(jobs, []corev1.VolumeMount{}, bdm.Disks{})
 			}
@@ -366,13 +366,6 @@ var _ = Describe("ContainerFactory", func() {
 			containers, err := act()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(containers[1].Env).To(HaveLen(5))
-		})
-
-		It("handles an error when jobs is empty", func() {
-			jobs = []bdm.Job{}
-			_, err := act()
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("instance group 'fake-ig' has no jobs defined"))
 		})
 
 		It("handles an error when getting release image fails", func() {
@@ -552,7 +545,7 @@ var _ = Describe("ContainerFactory", func() {
 
 				disableSideCar := ig.Env.AgentEnvBoshConfig.Agent.Settings.DisableLogSidecar
 
-				containerFactory := NewContainerFactory(ig.Name, "v1", disableSideCar, releaseImageProvider, bpmJobConfigs)
+				containerFactory := NewContainerFactory(ig.Name, false, "v1", disableSideCar, releaseImageProvider, bpmJobConfigs)
 				act := func() ([]corev1.Container, error) {
 					return containerFactory.JobsToContainers(ig.Jobs, []corev1.VolumeMount{}, bdm.Disks{})
 				}
@@ -579,7 +572,7 @@ var _ = Describe("ContainerFactory", func() {
 
 				disableSideCar := ig.Env.AgentEnvBoshConfig.Agent.Settings.DisableLogSidecar
 
-				containerFactory := NewContainerFactory(ig.Name, "v1", disableSideCar, releaseImageProvider, bpmJobConfigs)
+				containerFactory := NewContainerFactory(ig.Name, false, "v1", disableSideCar, releaseImageProvider, bpmJobConfigs)
 				act := func() ([]corev1.Container, error) {
 					return containerFactory.JobsToContainers(ig.Jobs, []corev1.VolumeMount{}, bdm.Disks{})
 				}

--- a/pkg/bosh/bpmconverter/resources_test.go
+++ b/pkg/bosh/bpmconverter/resources_test.go
@@ -38,7 +38,7 @@ var _ = Describe("BPM Converter", func() {
 		act := func(bpmConfigs bpm.Configs, instanceGroup *manifest.InstanceGroup) (*bpmconverter.Resources, error) {
 			c := bpmconverter.NewConverter(
 				volumeFactory,
-				func(instanceGroupName string, version string, disableLogSidecar bool, releaseImageProvider manifest.ReleaseImageProvider, bpmConfigs bpm.Configs) bpmconverter.ContainerFactory {
+				func(igName string, errand bool, version string, disableLogSidecar bool, releaseImageProvider manifest.ReleaseImageProvider, bpmConfigs bpm.Configs) bpmconverter.ContainerFactory {
 					return containerFactory
 				})
 			resources, err := c.Resources(*m, "foo", deploymentName, "1.2.3.4", "1", instanceGroup, bpmConfigs, "1")
@@ -599,6 +599,7 @@ var _ = Describe("BPM Converter", func() {
 					containers := resources.Errands[0].Spec.Template.Spec.Template.Spec.Containers
 
 					// Test shared volume setup
+					Expect(containers).To(HaveLen(1))
 					Expect(containers[0].VolumeMounts[0].Name).To(Equal("fake-volume-name"))
 					Expect(containers[0].VolumeMounts[0].MountPath).To(Equal("fake-mount-path"))
 				})
@@ -615,9 +616,10 @@ var _ = Describe("BPM Converter", func() {
 
 					c := bpmconverter.NewConverter(
 						bpmconverter.NewVolumeFactory(),
-						func(instanceGroupName string, version string, disableLogSidecar bool, releaseImageProvider manifest.ReleaseImageProvider, bpmConfigs bpm.Configs) bpmconverter.ContainerFactory {
+						func(igName string, errand bool, version string, disableLogSidecar bool, releaseImageProvider manifest.ReleaseImageProvider, bpmConfigs bpm.Configs) bpmconverter.ContainerFactory {
 							return bpmconverter.NewContainerFactory(
-								instanceGroupName,
+								igName,
+								false,
 								"1",
 								true,
 								releaseImageProvider,

--- a/pkg/bosh/manifest/disk.go
+++ b/pkg/bosh/manifest/disk.go
@@ -70,3 +70,20 @@ func (disks Disks) PVCs() []corev1.PersistentVolumeClaim {
 	}
 	return pvcs
 }
+
+// BPMMounts returns the volume mounts for the containers
+func (disks Disks) BPMMounts() (*corev1.VolumeMount, *corev1.VolumeMount) {
+	var ephemeralMount *corev1.VolumeMount
+	ephemeralDisks := disks.Filter("ephemeral", "true")
+	if len(ephemeralDisks) > 0 {
+		ephemeralMount = ephemeralDisks[0].VolumeMount
+	}
+
+	var persistentDiskMount *corev1.VolumeMount
+	persistentDiskDisks := disks.Filter("persistent", "true")
+	if len(persistentDiskDisks) > 0 {
+		persistentDiskMount = persistentDiskDisks[0].VolumeMount
+	}
+
+	return ephemeralMount, persistentDiskMount
+}

--- a/pkg/bosh/manifest/instance_group.go
+++ b/pkg/bosh/manifest/instance_group.go
@@ -102,6 +102,11 @@ func (ig *InstanceGroup) NameSanitized() string {
 	return names.Sanitize(ig.Name)
 }
 
+// IsErrand returns true if the  instance group is any kind of BOSH errand
+func (ig *InstanceGroup) IsErrand() bool {
+	return ig.LifeCycle == IGTypeErrand || ig.LifeCycle == IGTypeAutoErrand
+}
+
 // IndexedServiceName constructs an indexed service name. It's used to construct the service
 // names other than the headless service.
 func (ig *InstanceGroup) IndexedServiceName(index int, azIndex int) string {

--- a/pkg/kube/controllers/boshdeployment/bpm_controller.go
+++ b/pkg/kube/controllers/boshdeployment/bpm_controller.go
@@ -36,7 +36,7 @@ func AddBPM(ctx context.Context, config *config.Config, mgr manager.Manager) err
 		ctx, config, mgr,
 		desiredmanifest.NewDesiredManifest(mgr.GetClient()),
 		controllerutil.SetControllerReference,
-		bpmconverter.NewConverter(bpmconverter.NewVolumeFactory(), bpmconverter.NewContainerFactoryImplFunc),
+		bpmconverter.NewConverter(bpmconverter.NewVolumeFactory(), bpmconverter.NewContainerFactory),
 	)
 
 	// Create a new controller


### PR DESCRIPTION
This duplicates the existing container factory code for errands and removes
container-run from the container's command.

Fixes https://github.com/cloudfoundry-incubator/quarks-operator/issues/1318