### PR TITLE
Fix failing helm upgrade 

### DIFF
--- a/deploy/helm/quarks/templates/service-account-hooks.yml
+++ b/deploy/helm/quarks/templates/service-account-hooks.yml
@@ -13,4 +13,17 @@ metadata:
     "helm.sh/hook": {{$hook}}
     "helm.sh/hook-weight": "-2"
     "helm.sh/hook-delete-policy": before-hook-creation
+{{- if $.Values.global.image.credentials }}
+imagePullSecrets:
+- name: {{$hook}}-pull-secret
+---
+apiVersion: v1
+kind: Secret
+type: kubernetes.io/dockerconfigjson
+metadata:
+  name: {{$hook}}-pull-secret
+  namespace: {{ $.Release.Namespace | quote }}
+data:
+  .dockerconfigjson: {{ printf "{%q:{%q:{%q:%q,%q:%q,%q:%q}}}" "auths" $.Values.global.image.credentials.servername "username" $.Values.global.image.credentials.username "password" $.Values.global.image.credentials.password "auth" (printf "%s:%s" $.Values.global.image.credentials.username $.Values.global.image.credentials.password | b64enc) | b64enc }}
+{{- end }}
 {{- end }}


### PR DESCRIPTION
## Motivation and Context

Fix failing helm upgrade when using `.Values.global.image.credentials`. 

Fixes [#1311](https://github.com/cloudfoundry-incubator/quarks-operator/issues/1311)

## Checklist:

Check item if necessary.

- [ ] Review PRs of changed Quarks dependencies
- [ ] Update this PR after the release of Quarks dependencies
